### PR TITLE
Waveform storage and display improvements

### DIFF
--- a/Software/Web/src/components/capture/StreamDialog.vue
+++ b/Software/Web/src/components/capture/StreamDialog.vue
@@ -40,6 +40,7 @@
             dense
             outlined
             dark
+            :hint="maxSamplesHint"
           />
         </div>
 
@@ -130,6 +131,18 @@ const chunkSizeHint = computed(() => {
   if (freq < 3000) return ''
   const fps = (freq / localChunkSize.value).toFixed(1)
   return `~${fps} updates/sec (recommended: ${recommendedChunkSize.value} for ≥${TARGET_FPS} fps)`
+})
+
+const maxSamplesHint = computed(() => {
+  const n = localMaxSamples.value
+  const channels = channelConfig.selectedChannels.length || 1
+  // Per channel: raw buffer + pyramid levels (capacity/10 + capacity/100 + capacity/1000 + capacity/10000)
+  const perChannel = n + Math.ceil(n / 10) + Math.ceil(n / 100) + Math.ceil(n / 1000) + Math.ceil(n / 10000)
+  const totalBytes = perChannel * channels
+  const mb = (totalBytes / (1024 * 1024)).toFixed(1)
+  const freq = localFrequency.value
+  const seconds = freq > 0 ? (n / freq).toFixed(1) : '?'
+  return `~${mb} MB memory (${channels} ch), ~${seconds}s of data`
 })
 
 const frequencyHint = computed(() => {

--- a/Software/Web/src/components/viewer/MinimapBar.vue
+++ b/Software/Web/src/components/viewer/MinimapBar.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="minimap-bar">
+    <div class="minimap-controls">
+      <q-btn
+        flat
+        dense
+        round
+        size="sm"
+        icon="remove"
+        color="grey-4"
+        :disable="!viewport.canZoomOut"
+        @click="viewport.zoomOut()"
+      />
+      <span class="zoom-label text-caption">{{ zoomLabel }}</span>
+      <q-btn
+        flat
+        dense
+        round
+        size="sm"
+        icon="add"
+        color="grey-4"
+        :disable="!viewport.canZoomIn"
+        @click="viewport.zoomIn()"
+      />
+      <q-btn
+        flat
+        dense
+        round
+        size="sm"
+        icon="fit_screen"
+        color="grey-4"
+        title="Fit all"
+        @click="viewport.fitAll()"
+      />
+      <q-btn
+        v-if="stream.isStreaming"
+        flat
+        dense
+        round
+        size="sm"
+        :icon="stream.following ? 'gps_fixed' : 'gps_not_fixed'"
+        :color="stream.following ? 'positive' : 'grey-4'"
+        title="Follow latest data"
+        @click="stream.following = !stream.following"
+      />
+    </div>
+
+    <div
+      ref="containerRef"
+      class="minimap-canvas-container"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointerleave="onPointerUp"
+    >
+      <canvas ref="canvasRef" class="minimap-canvas" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, shallowRef, computed, watchEffect, onMounted, onBeforeUnmount } from 'vue'
+import { MinimapRenderer } from 'src/core/renderer/minimap-renderer.js'
+import { useViewportStore } from 'src/stores/viewport.js'
+import { useCapture } from 'src/composables/useCapture.js'
+import { useStream } from 'src/composables/useStream.js'
+
+const containerRef = ref(null)
+const canvasRef = ref(null)
+const renderer = shallowRef(null)
+
+const viewport = useViewportStore()
+const cap = useCapture()
+const stream = useStream()
+
+// ── Active channels (same logic as WaveformCanvas) ─────────────────────
+
+const activeChannels = computed(() => {
+  if (stream.isStreaming || stream.streamChannels.length > 0) return stream.streamChannels
+  return cap.capturedChannels
+})
+
+function mapChannels(channels) {
+  if (!channels) return []
+  return channels.map((ch) => ({
+    channelNumber: ch.channelNumber,
+    channelColor: ch.channelColor,
+    visible: !ch.hidden,
+    samples: ch.samples,
+  }))
+}
+
+// ── Zoom label ─────────────────────────────────────────────────────────
+
+const zoomLabel = computed(() => {
+  if (viewport.canvasWidth === 0 || viewport.visibleSamples === 0) return '1.00x'
+  const pps = viewport.canvasWidth / viewport.visibleSamples
+  if (pps >= 100) return `${pps.toFixed(0)}x`
+  if (pps >= 10) return `${pps.toFixed(1)}x`
+  if (pps >= 0.01) return `${pps.toFixed(2)}x`
+  return `${pps.toExponential(1)}x`
+})
+
+// ── Lifecycle ──────────────────────────────────────────────────────────
+
+let resizeObserver = null
+let rafId = null
+
+function scheduleRender() {
+  if (rafId) return
+  rafId = requestAnimationFrame(() => {
+    rafId = null
+    if (renderer.value) {
+      renderer.value.resize()
+      renderer.value.render()
+    }
+  })
+}
+
+onMounted(() => {
+  renderer.value = new MinimapRenderer(canvasRef.value)
+  renderer.value.resize()
+
+  resizeObserver = new ResizeObserver(() => {
+    scheduleRender()
+  })
+  resizeObserver.observe(containerRef.value)
+})
+
+onBeforeUnmount(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+  if (rafId) {
+    cancelAnimationFrame(rafId)
+    rafId = null
+  }
+  if (renderer.value) {
+    renderer.value.dispose()
+    renderer.value = null
+  }
+})
+
+watchEffect(() => {
+  if (!renderer.value) return
+  renderer.value.setChannels(mapChannels(activeChannels.value))
+  renderer.value.setTotalSamples(viewport.totalSamples)
+  renderer.value.setViewport(viewport.firstSample, viewport.visibleSamples)
+  renderer.value.resize()
+  renderer.value.render()
+})
+
+// ── Drag interaction ───────────────────────────────────────────────────
+
+let dragging = false
+let dragOffsetSamples = 0
+
+function onPointerDown(e) {
+  const r = renderer.value
+  if (!r || viewport.totalSamples === 0) return
+
+  const rect = containerRef.value.getBoundingClientRect()
+  const x = e.clientX - rect.left
+  const clickedSample = r.sampleAtX(x)
+
+  if (r.isInsideViewport(x)) {
+    dragging = true
+    dragOffsetSamples = clickedSample - viewport.firstSample
+    containerRef.value.setPointerCapture(e.pointerId)
+  } else {
+    if (stream.isStreaming) stream.following = false
+    const newFirst = clickedSample - Math.floor(viewport.visibleSamples / 2)
+    viewport.setView(newFirst, viewport.visibleSamples)
+  }
+}
+
+function onPointerMove(e) {
+  if (!dragging || !renderer.value) return
+
+  const rect = containerRef.value.getBoundingClientRect()
+  const x = e.clientX - rect.left
+  const sample = renderer.value.sampleAtX(x)
+
+  if (stream.isStreaming) stream.following = false
+  viewport.setView(sample - dragOffsetSamples, viewport.visibleSamples)
+}
+
+function onPointerUp(e) {
+  if (dragging) {
+    dragging = false
+    try {
+      containerRef.value?.releasePointerCapture(e.pointerId)
+    } catch {
+      /* ignore if already released */
+    }
+  }
+}
+</script>
+
+<style scoped>
+.minimap-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+  height: 32px;
+  background: rgb(28, 28, 28);
+  border-bottom: 1px solid rgb(60, 60, 60);
+}
+
+.minimap-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.zoom-label {
+  min-width: 52px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}
+
+.minimap-canvas-container {
+  flex: 1;
+  height: 24px;
+  overflow: hidden;
+  cursor: pointer;
+  border-radius: 3px;
+  border: 1px solid rgb(50, 50, 50);
+}
+
+.minimap-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/Software/Web/src/components/viewer/WaveformCanvas.vue
+++ b/Software/Web/src/components/viewer/WaveformCanvas.vue
@@ -81,6 +81,7 @@ function scheduleRender() {
       renderer.value.resize()
       renderer.value.render()
       emit('channel-height-update', renderer.value.channelHeight)
+      viewport.setCanvasWidth(renderer.value._width)
     }
   })
 }
@@ -134,6 +135,7 @@ watchEffect(() => {
   renderer.value.resize()
   renderer.value.render()
   emit('channel-height-update', renderer.value.channelHeight)
+  viewport.setCanvasWidth(renderer.value._width)
 })
 
 defineExpose({ renderer })

--- a/Software/Web/src/components/viewer/WaveformCanvas.vue
+++ b/Software/Web/src/components/viewer/WaveformCanvas.vue
@@ -13,8 +13,10 @@ import { ref, shallowRef, watchEffect, computed, onMounted, onBeforeUnmount } fr
 import { WaveformRenderer, MIN_CHANNEL_HEIGHT } from 'src/core/renderer/waveform-renderer.js'
 import { COLORS } from 'src/core/renderer/colors.js'
 import { useViewportStore } from 'src/stores/viewport.js'
+import { useCursorStore } from 'src/stores/cursor.js'
 import { useCapture } from 'src/composables/useCapture.js'
 import { useStream } from 'src/composables/useStream.js'
+import { useWaveformInput } from 'src/composables/useWaveformInput.js'
 
 const emit = defineEmits(['channel-height-update'])
 
@@ -23,8 +25,11 @@ const canvasRef = ref(null)
 const renderer = shallowRef(null)
 
 const viewport = useViewportStore()
+const cursor = useCursorStore()
 const cap = useCapture()
 const stream = useStream()
+
+useWaveformInput(canvasRef, renderer)
 
 const activeChannels = computed(() => {
   if (stream.isStreaming || stream.streamChannels.length > 0) return stream.streamChannels
@@ -65,30 +70,6 @@ function mapRegions(regions) {
   }))
 }
 
-function onWheel(event) {
-  if (!renderer.value) return
-
-  // Disable follow on manual scroll/zoom during stream
-  if (stream.isStreaming) {
-    stream.following = false
-  }
-
-  if (event.ctrlKey || event.metaKey) {
-    event.preventDefault()
-    const sampleAtCursor = renderer.value.sampleAtX(event.offsetX)
-    if (event.deltaY < 0) viewport.zoomIn(sampleAtCursor)
-    else viewport.zoomOut(sampleAtCursor)
-  } else {
-    event.preventDefault()
-    const scrollAmount = Math.max(1, Math.floor(viewport.visibleSamples * 0.1))
-    if (event.shiftKey) {
-      viewport.scrollBy(event.deltaY > 0 ? scrollAmount : -scrollAmount)
-    } else {
-      viewport.scrollBy(event.deltaY > 0 ? scrollAmount : -scrollAmount)
-    }
-  }
-}
-
 let resizeObserver = null
 let rafId = null
 
@@ -112,8 +93,6 @@ onMounted(() => {
     scheduleRender()
   })
   resizeObserver.observe(containerRef.value)
-
-  canvasRef.value.addEventListener('wheel', onWheel, { passive: false })
 })
 
 onBeforeUnmount(() => {
@@ -124,9 +103,6 @@ onBeforeUnmount(() => {
   if (rafId) {
     cancelAnimationFrame(rafId)
     rafId = null
-  }
-  if (canvasRef.value) {
-    canvasRef.value.removeEventListener('wheel', onWheel)
   }
   if (renderer.value) {
     renderer.value.dispose()
@@ -154,6 +130,7 @@ watchEffect(() => {
     renderer.value.setBursts(mapBursts(cap.bursts))
     renderer.value.setRegions(mapRegions(cap.regions))
   }
+  renderer.value.setCursorX(cursor.cursorX)
   renderer.value.resize()
   renderer.value.render()
   emit('channel-height-update', renderer.value.channelHeight)

--- a/Software/Web/src/components/viewer/WaveformViewer.vue
+++ b/Software/Web/src/components/viewer/WaveformViewer.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="waveform-viewer">
+    <MinimapBar class="wv-minimap" />
+
     <div class="wv-corner" />
     <TimelineRuler class="wv-timeline" />
 
@@ -7,85 +9,22 @@
       <ChannelLabels class="wv-labels" :channel-height="channelHeight" />
       <WaveformCanvas class="wv-canvas" @channel-height-update="channelHeight = $event" />
     </div>
-
-    <div class="wv-controls">
-      <q-btn
-        flat
-        dense
-        round
-        size="sm"
-        icon="zoom_out"
-        color="grey-4"
-        :disable="!viewport.canZoomOut"
-        @click="viewport.zoomOut()"
-      />
-      <q-slider
-        :model-value="scrollPosition"
-        :min="0"
-        :max="scrollMax"
-        :step="scrollStep"
-        dense
-        color="grey-6"
-        class="col"
-        @update:model-value="onScrollChange"
-      />
-      <q-btn
-        flat
-        dense
-        round
-        size="sm"
-        icon="zoom_in"
-        color="grey-4"
-        :disable="!viewport.canZoomIn"
-        @click="viewport.zoomIn()"
-      />
-      <q-btn
-        flat
-        dense
-        round
-        size="sm"
-        icon="fit_screen"
-        color="grey-4"
-        @click="viewport.fitAll()"
-      />
-      <q-btn
-        v-if="stream.isStreaming"
-        flat
-        dense
-        round
-        size="sm"
-        :icon="stream.following ? 'gps_fixed' : 'gps_not_fixed'"
-        :color="stream.following ? 'positive' : 'grey-4'"
-        title="Follow latest data"
-        @click="stream.following = !stream.following"
-      />
-    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useViewportStore } from 'src/stores/viewport.js'
 import { useCapture } from 'src/composables/useCapture.js'
-import { useStream } from 'src/composables/useStream.js'
 import { MIN_CHANNEL_HEIGHT } from 'src/core/renderer/waveform-renderer.js'
+import MinimapBar from './MinimapBar.vue'
 import TimelineRuler from './TimelineRuler.vue'
 import ChannelLabels from './ChannelLabels.vue'
 import WaveformCanvas from './WaveformCanvas.vue'
 const viewport = useViewportStore()
 const cap = useCapture()
-const stream = useStream()
 
 const channelHeight = ref(MIN_CHANNEL_HEIGHT)
-
-const scrollPosition = computed(() => viewport.firstSample)
-const scrollMax = computed(() => Math.max(0, viewport.totalSamples - viewport.visibleSamples))
-const scrollStep = computed(() => Math.max(1, Math.floor(viewport.visibleSamples * 0.01)))
-
-function onScrollChange(val) {
-  if (stream.isStreaming) stream.following = false
-  viewport.setView(val, viewport.visibleSamples)
-}
 
 watch(
   () => cap.hasCapture,
@@ -99,27 +38,32 @@ watch(
 .waveform-viewer {
   display: grid;
   grid-template-columns: 160px 1fr;
-  grid-template-rows: 32px 1fr auto;
+  grid-template-rows: 32px 32px 1fr;
   height: 100%;
   overflow: hidden;
   background: rgb(28, 28, 28);
 }
 
+.wv-minimap {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
 .wv-corner {
-  grid-area: 1 / 1;
+  grid-area: 2 / 1;
   background: rgb(28, 28, 28);
   border-right: 1px solid rgb(60, 60, 60);
   border-bottom: 1px solid rgb(60, 60, 60);
 }
 
 .wv-timeline {
-  grid-area: 1 / 2;
+  grid-area: 2 / 2;
   border-bottom: 1px solid rgb(60, 60, 60);
 }
 
 .wv-channels {
   grid-column: 1 / -1;
-  grid-row: 2;
+  grid-row: 3;
   display: grid;
   grid-template-columns: 160px 1fr;
   min-height: 0;
@@ -133,15 +77,5 @@ watch(
 
 .wv-canvas {
   grid-column: 2;
-}
-
-.wv-controls {
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  background: rgb(32, 32, 32);
-  border-top: 1px solid rgb(60, 60, 60);
 }
 </style>

--- a/Software/Web/src/composables/useWaveformInput.js
+++ b/Software/Web/src/composables/useWaveformInput.js
@@ -17,6 +17,29 @@ export function useWaveformInput(canvasRef, rendererRef) {
 
   let manager = null
 
+  /**
+   * Recalculate cursor sample and snapped position from the raw mouse pixel.
+   * Called after viewport changes (zoom) so the cursor stays accurate.
+   */
+  function updateCursorFromRaw() {
+    const renderer = rendererRef.value
+    if (!renderer || cursor.rawX == null) return
+
+    const offsetX = cursor.rawX
+    const sample = renderer.sampleAtX(offsetX)
+    const sampleWidth = renderer._width / renderer.visibleSamples
+
+    let snappedX
+    if (sampleWidth >= 1) {
+      snappedX = renderer.xAtSample(sample) + sampleWidth / 2
+    } else {
+      snappedX = offsetX
+    }
+
+    cursor.setCursor(sample, snappedX, offsetX)
+    renderer.setCursorX(snappedX)
+  }
+
   function handleZoom({ delta }) {
     // Disable follow on manual zoom during stream
     if (stream.streaming) {
@@ -31,6 +54,9 @@ export function useWaveformInput(canvasRef, rendererRef) {
     } else {
       viewport.zoomOut(center)
     }
+
+    // Recalculate cursor position for the new viewport
+    updateCursorFromRaw()
   }
 
   function handleCursorMove({ offsetX }) {
@@ -42,14 +68,12 @@ export function useWaveformInput(canvasRef, rendererRef) {
 
     let snappedX
     if (sampleWidth >= 1) {
-      // Zoomed in: snap to center of the sample column
       snappedX = renderer.xAtSample(sample) + sampleWidth / 2
     } else {
-      // Zoomed out: follow mouse exactly
       snappedX = offsetX
     }
 
-    cursor.setCursor(sample, snappedX)
+    cursor.setCursor(sample, snappedX, offsetX)
     renderer.setCursorX(snappedX)
   }
 

--- a/Software/Web/src/composables/useWaveformInput.js
+++ b/Software/Web/src/composables/useWaveformInput.js
@@ -1,0 +1,82 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+import { InputManager } from 'src/core/input/input-manager.js'
+import { useViewportStore } from 'src/stores/viewport.js'
+import { useStreamStore } from 'src/stores/stream.js'
+import { useCursorStore } from 'src/stores/cursor.js'
+
+/**
+ * Composable that wires InputManager to Pinia stores and the waveform renderer.
+ *
+ * @param {import('vue').Ref<HTMLCanvasElement|null>} canvasRef - template ref to the canvas element
+ * @param {import('vue').ShallowRef<import('src/core/renderer/waveform-renderer.js').WaveformRenderer|null>} rendererRef - shallow ref to the renderer
+ */
+export function useWaveformInput(canvasRef, rendererRef) {
+  const viewport = useViewportStore()
+  const stream = useStreamStore()
+  const cursor = useCursorStore()
+
+  let manager = null
+
+  function handleZoom({ delta }) {
+    // Disable follow on manual zoom during stream
+    if (stream.streaming) {
+      stream.following = false
+    }
+
+    // Determine zoom center — use cursor sample if available, otherwise viewport center
+    const center = cursor.cursorSample
+
+    if (delta > 0) {
+      viewport.zoomIn(center)
+    } else {
+      viewport.zoomOut(center)
+    }
+  }
+
+  function handleCursorMove({ offsetX }) {
+    const renderer = rendererRef.value
+    if (!renderer) return
+
+    const sample = renderer.sampleAtX(offsetX)
+    const sampleWidth = renderer._width / renderer.visibleSamples
+
+    let snappedX
+    if (sampleWidth >= 1) {
+      // Zoomed in: snap to center of the sample column
+      snappedX = renderer.xAtSample(sample) + sampleWidth / 2
+    } else {
+      // Zoomed out: follow mouse exactly
+      snappedX = offsetX
+    }
+
+    cursor.setCursor(sample, snappedX)
+    renderer.setCursorX(snappedX)
+  }
+
+  function handleCursorLeave() {
+    cursor.clearCursor()
+    const renderer = rendererRef.value
+    if (renderer) renderer.setCursorX(null)
+  }
+
+  onMounted(() => {
+    manager = new InputManager()
+
+    if (canvasRef.value) {
+      manager.bind(canvasRef.value, 'canvas')
+    }
+    manager.bind(window, 'window')
+
+    manager.on('zoom', handleZoom)
+    manager.on('cursor-move', handleCursorMove)
+    manager.on('cursor-leave', handleCursorLeave)
+  })
+
+  onBeforeUnmount(() => {
+    if (manager) {
+      manager.dispose()
+      manager = null
+    }
+    cursor.clearCursor()
+  })
+}

--- a/Software/Web/src/composables/useWaveformInput.js
+++ b/Software/Web/src/composables/useWaveformInput.js
@@ -103,6 +103,12 @@ export function useWaveformInput(canvasRef, rendererRef) {
     renderer.setCursorX(snappedX)
   }
 
+  function handleScroll({ delta }) {
+    if (stream.streaming) stream.following = false
+    const amount = Math.round(delta * viewport.visibleSamples)
+    viewport.scrollBy(amount)
+  }
+
   function handleCursorLeave() {
     cursor.clearCursor()
     const renderer = rendererRef.value
@@ -118,6 +124,7 @@ export function useWaveformInput(canvasRef, rendererRef) {
     manager.bind(window, 'window')
 
     manager.on('zoom', handleZoom)
+    manager.on('scroll', handleScroll)
     manager.on('cursor-move', handleCursorMove)
     manager.on('cursor-leave', handleCursorLeave)
   })

--- a/Software/Web/src/composables/useWaveformInput.js
+++ b/Software/Web/src/composables/useWaveformInput.js
@@ -18,6 +18,25 @@ export function useWaveformInput(canvasRef, rendererRef) {
   let manager = null
 
   /**
+   * Compute cursor state from a raw pixel position and viewport values.
+   * Uses store values (synchronously current) rather than the renderer
+   * (which updates asynchronously via watchEffect and may be stale after zoom).
+   */
+  function computeCursor(offsetX, first, visible, width) {
+    const sample = Math.floor((offsetX / width) * visible) + first
+    const sampleWidth = width / visible
+
+    let snappedX
+    if (sampleWidth >= 1) {
+      snappedX = ((sample - first) / visible) * width + sampleWidth / 2
+    } else {
+      snappedX = offsetX
+    }
+
+    return { sample, snappedX }
+  }
+
+  /**
    * Recalculate cursor sample and snapped position from the raw mouse pixel.
    * Called after viewport changes (zoom) so the cursor stays accurate.
    */
@@ -25,18 +44,17 @@ export function useWaveformInput(canvasRef, rendererRef) {
     const renderer = rendererRef.value
     if (!renderer || cursor.rawX == null) return
 
-    const offsetX = cursor.rawX
-    const sample = renderer.sampleAtX(offsetX)
-    const sampleWidth = renderer._width / renderer.visibleSamples
+    const width = renderer._width
+    if (width === 0) return
 
-    let snappedX
-    if (sampleWidth >= 1) {
-      snappedX = renderer.xAtSample(sample) + sampleWidth / 2
-    } else {
-      snappedX = offsetX
-    }
+    const { sample, snappedX } = computeCursor(
+      cursor.rawX,
+      viewport.firstSample,
+      viewport.visibleSamples,
+      width,
+    )
 
-    cursor.setCursor(sample, snappedX, offsetX)
+    cursor.setCursor(sample, snappedX, cursor.rawX)
     renderer.setCursorX(snappedX)
   }
 
@@ -46,13 +64,21 @@ export function useWaveformInput(canvasRef, rendererRef) {
       stream.following = false
     }
 
-    // Determine zoom center — use cursor sample if available, otherwise viewport center
-    const center = cursor.cursorSample
+    const renderer = rendererRef.value
+    const width = renderer?._width || 0
+
+    // Compute anchor sample and its screen fraction
+    let anchor = null
+    let fraction = 0.5
+    if (cursor.cursorSample != null && width > 0) {
+      anchor = cursor.cursorSample
+      fraction = Math.max(0, Math.min(1, cursor.rawX / width))
+    }
 
     if (delta > 0) {
-      viewport.zoomIn(center)
+      viewport.zoomIn(anchor, fraction)
     } else {
-      viewport.zoomOut(center)
+      viewport.zoomOut(anchor, fraction)
     }
 
     // Recalculate cursor position for the new viewport
@@ -63,15 +89,15 @@ export function useWaveformInput(canvasRef, rendererRef) {
     const renderer = rendererRef.value
     if (!renderer) return
 
-    const sample = renderer.sampleAtX(offsetX)
-    const sampleWidth = renderer._width / renderer.visibleSamples
+    const width = renderer._width
+    if (width === 0) return
 
-    let snappedX
-    if (sampleWidth >= 1) {
-      snappedX = renderer.xAtSample(sample) + sampleWidth / 2
-    } else {
-      snappedX = offsetX
-    }
+    const { sample, snappedX } = computeCursor(
+      offsetX,
+      viewport.firstSample,
+      viewport.visibleSamples,
+      width,
+    )
 
     cursor.setCursor(sample, snappedX, offsetX)
     renderer.setCursorX(snappedX)

--- a/Software/Web/src/core/capture/formats.js
+++ b/Software/Web/src/core/capture/formats.js
@@ -8,16 +8,18 @@
  */
 
 import { getTotalSamples } from '../driver/types.js'
+import { SampleBuffer } from '../sample-buffer.js'
 
 // ─── Internal mapping: .lac JSON (PascalCase) → JS (camelCase) ───
 
 function channelFromLac(ch) {
+  const raw = ch.Samples ? new Uint8Array(ch.Samples) : null
   return {
     channelNumber: ch.ChannelNumber,
     channelName: ch.ChannelName ?? '',
     channelColor: ch.ChannelColor ?? null,
     hidden: ch.Hidden ?? false,
-    samples: ch.Samples ? new Uint8Array(ch.Samples) : null,
+    samples: raw ? SampleBuffer.fromUint8Array(raw) : null,
   }
 }
 
@@ -64,12 +66,17 @@ function sessionFromLac(s) {
 // ─── Internal mapping: JS (camelCase) → .lac JSON (PascalCase) ───
 
 function channelToLac(ch) {
+  let samplesArray = null
+  if (ch.samples) {
+    const raw = ch.samples.toUint8Array ? ch.samples.toUint8Array() : ch.samples
+    samplesArray = Array.from(raw)
+  }
   return {
     ChannelNumber: ch.channelNumber,
     ChannelName: ch.channelName,
     ChannelColor: ch.channelColor,
     Hidden: ch.hidden,
-    Samples: ch.samples ? Array.from(ch.samples) : null,
+    Samples: samplesArray,
   }
 }
 
@@ -123,11 +130,11 @@ function applyLegacySamples(session, legacySamples) {
   for (const ch of session.captureChannels) {
     if (ch.samples) continue // already has per-channel data
     const mask = 1 << ch.channelNumber
-    const result = new Uint8Array(legacySamples.length)
+    const raw = new Uint8Array(legacySamples.length)
     for (let i = 0; i < legacySamples.length; i++) {
-      result[i] = (legacySamples[i] & mask) !== 0 ? 1 : 0
+      raw[i] = (legacySamples[i] & mask) !== 0 ? 1 : 0
     }
-    ch.samples = result
+    ch.samples = SampleBuffer.fromUint8Array(raw)
   }
 }
 
@@ -198,7 +205,7 @@ export function parseCsv(csvString) {
     channelName: name,
     channelColor: null,
     hidden: false,
-    samples: samplesArrays[i],
+    samples: SampleBuffer.fromUint8Array(samplesArrays[i]),
   }))
 
   return { channels }
@@ -222,7 +229,12 @@ export function serializeCsv(session) {
   const lines = [header]
 
   for (let s = 0; s < totalSamples; s++) {
-    const row = channels.map((ch) => (ch.samples ? ch.samples[s] : 0)).join(',')
+    const row = channels
+      .map((ch) => {
+        if (!ch.samples) return 0
+        return ch.samples.get ? ch.samples.get(s) : ch.samples[s]
+      })
+      .join(',')
     lines.push(row)
   }
 

--- a/Software/Web/src/core/capture/formats.test.js
+++ b/Software/Web/src/core/capture/formats.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { parseLac, serializeLac, parseCsv, serializeCsv } from './formats.js'
+import { SampleBuffer } from '../sample-buffer.js'
+
+/** Helper: get raw Uint8Array from a SampleBuffer or Uint8Array */
+function samplesArray(samples) {
+  if (!samples) return null
+  return samples.toUint8Array ? samples.toUint8Array() : samples
+}
 
 describe('parseLac', () => {
   it('parses modern format with per-channel samples', () => {
@@ -43,7 +50,10 @@ describe('parseLac', () => {
     expect(session.postTriggerSamples).toBe(100)
     expect(session.captureChannels).toHaveLength(2)
     expect(session.captureChannels[0].channelName).toBe('CLK')
-    expect(session.captureChannels[0].samples).toEqual(new Uint8Array([1, 0, 1, 0]))
+    expect(session.captureChannels[0].samples).toBeInstanceOf(SampleBuffer)
+    expect(samplesArray(session.captureChannels[0].samples)).toEqual(
+      new Uint8Array([1, 0, 1, 0]),
+    )
     expect(session.captureChannels[1].channelColor).toBe(0xff0000ff)
     expect(session.captureChannels[1].hidden).toBe(true)
     expect(regions).toEqual([])
@@ -66,8 +76,12 @@ describe('parseLac', () => {
     }
 
     const { session } = parseLac(JSON.stringify(lac))
-    expect(session.captureChannels[0].samples).toEqual(new Uint8Array([1, 1, 0, 0]))
-    expect(session.captureChannels[1].samples).toEqual(new Uint8Array([1, 0, 1, 0]))
+    expect(samplesArray(session.captureChannels[0].samples)).toEqual(
+      new Uint8Array([1, 1, 0, 0]),
+    )
+    expect(samplesArray(session.captureChannels[1].samples)).toEqual(
+      new Uint8Array([1, 0, 1, 0]),
+    )
   })
 
   it('parses regions with R/G/B/A color', () => {
@@ -186,9 +200,42 @@ describe('serializeLac', () => {
     expect(result.session.frequency).toBe(2000000)
     expect(result.session.preTriggerSamples).toBe(20)
     expect(result.session.captureChannels[0].channelName).toBe('SDA')
-    expect(result.session.captureChannels[0].samples).toEqual(new Uint8Array([1, 0, 1]))
+    expect(samplesArray(result.session.captureChannels[0].samples)).toEqual(
+      new Uint8Array([1, 0, 1]),
+    )
     expect(result.regions[0].regionName).toBe('R1')
     expect(result.regions[0].regionColor).toEqual({ r: 100, g: 200, b: 50, a: 180 })
+  })
+
+  it('round-trips SampleBuffer through parseLac', () => {
+    const session = {
+      frequency: 1000000,
+      preTriggerSamples: 0,
+      postTriggerSamples: 3,
+      loopCount: 0,
+      measureBursts: false,
+      captureChannels: [
+        {
+          channelNumber: 0,
+          channelName: 'CH0',
+          channelColor: null,
+          hidden: false,
+          samples: SampleBuffer.fromUint8Array(new Uint8Array([1, 0, 1])),
+        },
+      ],
+      bursts: null,
+      triggerType: 0,
+      triggerChannel: 0,
+      triggerInverted: false,
+      triggerBitCount: 0,
+      triggerPattern: 0,
+    }
+
+    const json = serializeLac(session)
+    const result = parseLac(json)
+    expect(samplesArray(result.session.captureChannels[0].samples)).toEqual(
+      new Uint8Array([1, 0, 1]),
+    )
   })
 
   it('uses PascalCase keys in output', () => {
@@ -292,9 +339,10 @@ describe('parseCsv', () => {
     const { channels } = parseCsv(csv)
     expect(channels).toHaveLength(2)
     expect(channels[0].channelName).toBe('CLK')
-    expect(channels[0].samples).toEqual(new Uint8Array([1, 0, 1, 0]))
+    expect(channels[0].samples).toBeInstanceOf(SampleBuffer)
+    expect(samplesArray(channels[0].samples)).toEqual(new Uint8Array([1, 0, 1, 0]))
     expect(channels[1].channelName).toBe('DATA')
-    expect(channels[1].samples).toEqual(new Uint8Array([0, 1, 1, 0]))
+    expect(samplesArray(channels[1].samples)).toEqual(new Uint8Array([0, 1, 1, 0]))
   })
 
   it('parses single channel', () => {
@@ -302,14 +350,14 @@ describe('parseCsv', () => {
     const { channels } = parseCsv(csv)
     expect(channels).toHaveLength(1)
     expect(channels[0].channelName).toBe('Signal')
-    expect(channels[0].samples).toEqual(new Uint8Array([1, 0, 1]))
+    expect(samplesArray(channels[0].samples)).toEqual(new Uint8Array([1, 0, 1]))
   })
 
   it('returns empty for header only', () => {
     const csv = 'CLK,DATA'
     const { channels } = parseCsv(csv)
     expect(channels).toHaveLength(2)
-    expect(channels[0].samples).toEqual(new Uint8Array(0))
+    expect(samplesArray(channels[0].samples)).toEqual(new Uint8Array(0))
   })
 
   it('returns empty for empty string', () => {
@@ -342,9 +390,29 @@ describe('serializeCsv', () => {
     const csv = serializeCsv(session)
     const { channels } = parseCsv(csv)
     expect(channels[0].channelName).toBe('CLK')
-    expect(channels[0].samples).toEqual(new Uint8Array([1, 0, 1]))
+    expect(samplesArray(channels[0].samples)).toEqual(new Uint8Array([1, 0, 1]))
     expect(channels[1].channelName).toBe('DATA')
-    expect(channels[1].samples).toEqual(new Uint8Array([0, 1, 0]))
+    expect(samplesArray(channels[1].samples)).toEqual(new Uint8Array([0, 1, 0]))
+  })
+
+  it('round-trips SampleBuffer through parseCsv', () => {
+    const session = {
+      frequency: 1000000,
+      preTriggerSamples: 0,
+      postTriggerSamples: 3,
+      loopCount: 0,
+      captureChannels: [
+        {
+          channelNumber: 0,
+          channelName: 'CH0',
+          samples: SampleBuffer.fromUint8Array(new Uint8Array([1, 0, 1])),
+        },
+      ],
+    }
+
+    const csv = serializeCsv(session)
+    const { channels } = parseCsv(csv)
+    expect(samplesArray(channels[0].samples)).toEqual(new Uint8Array([1, 0, 1]))
   })
 
   it('uses fallback channel names', () => {

--- a/Software/Web/src/core/driver/analyzer.test.js
+++ b/Software/Web/src/core/driver/analyzer.test.js
@@ -530,8 +530,12 @@ describe('AnalyzerDriver', () => {
       expect(onComplete).toHaveBeenCalledOnce()
       const result = onComplete.mock.calls[0][0]
       expect(result.success).toBe(true)
-      expect(result.session.captureChannels[0].samples).toEqual(new Uint8Array([1, 1, 0, 0]))
-      expect(result.session.captureChannels[1].samples).toEqual(new Uint8Array([1, 0, 1, 0]))
+      expect(result.session.captureChannels[0].samples.toUint8Array()).toEqual(
+        new Uint8Array([1, 1, 0, 0]),
+      )
+      expect(result.session.captureChannels[1].samples.toUint8Array()).toEqual(
+        new Uint8Array([1, 0, 1, 0]),
+      )
     })
 
     it('calls onComplete with success=false for empty channels', async () => {

--- a/Software/Web/src/core/driver/samples.js
+++ b/Software/Web/src/core/driver/samples.js
@@ -4,21 +4,24 @@
  * burst processing (LogicAnalyzerDriver.cs:529-616).
  */
 
+import { SampleBuffer } from '../sample-buffer.js'
+
 /**
  * Extracts per-channel sample data from raw packed samples.
  * Each raw sample is a uint32 with bits representing channel states.
+ * Returns a SampleBuffer with pre-built decimation pyramid.
  *
  * @param {Uint32Array} rawSamples - Packed multi-channel samples
  * @param {number} channelIndex - Which channel to extract (0-based bit position)
- * @returns {Uint8Array} 0/1 per sample
+ * @returns {SampleBuffer} 0/1 per sample with decimation pyramid
  */
 export function extractSamples(rawSamples, channelIndex) {
   const mask = 1 << channelIndex
-  const result = new Uint8Array(rawSamples.length)
+  const raw = new Uint8Array(rawSamples.length)
   for (let i = 0; i < rawSamples.length; i++) {
-    result[i] = (rawSamples[i] & mask) !== 0 ? 1 : 0
+    raw[i] = (rawSamples[i] & mask) !== 0 ? 1 : 0
   }
-  return result
+  return SampleBuffer.fromUint8Array(raw)
 }
 
 /**

--- a/Software/Web/src/core/driver/samples.test.js
+++ b/Software/Web/src/core/driver/samples.test.js
@@ -1,55 +1,68 @@
 import { describe, it, expect } from 'vitest'
 import { extractSamples, processBurstTimestamps } from './samples.js'
 
+/** Helper: extract samples and return as plain Uint8Array for assertion. */
+function extractAsArray(raw, channelIndex) {
+  return extractSamples(raw, channelIndex).toUint8Array()
+}
+
 describe('extractSamples', () => {
+  it('returns a SampleBuffer with get() and length', () => {
+    const raw = new Uint32Array([0b00000001, 0b00000000])
+    const buf = extractSamples(raw, 0)
+    expect(buf.length).toBe(2)
+    expect(buf.get(0)).toBe(1)
+    expect(buf.get(1)).toBe(0)
+  })
+
   it('extracts channel 0 from 8-bit samples', () => {
     // Bit 0: 1,0,1,0
     const raw = new Uint32Array([0b00000001, 0b00000000, 0b00000001, 0b00000000])
-    expect(extractSamples(raw, 0)).toEqual(new Uint8Array([1, 0, 1, 0]))
+    expect(extractAsArray(raw, 0)).toEqual(new Uint8Array([1, 0, 1, 0]))
   })
 
   it('extracts channel 3 from 8-bit samples', () => {
     // Bit 3 = 0x08: set in first and third
     const raw = new Uint32Array([0b00001000, 0b00000000, 0b00001000, 0b00000100])
-    expect(extractSamples(raw, 3)).toEqual(new Uint8Array([1, 0, 1, 0]))
+    expect(extractAsArray(raw, 3)).toEqual(new Uint8Array([1, 0, 1, 0]))
   })
 
   it('extracts channel 7', () => {
     const raw = new Uint32Array([0x80, 0x00, 0xff])
-    expect(extractSamples(raw, 7)).toEqual(new Uint8Array([1, 0, 1]))
+    expect(extractAsArray(raw, 7)).toEqual(new Uint8Array([1, 0, 1]))
   })
 
   it('extracts higher channel indices (channel 15)', () => {
     const raw = new Uint32Array([0x8000, 0x0000, 0xffff])
-    expect(extractSamples(raw, 15)).toEqual(new Uint8Array([1, 0, 1]))
+    expect(extractAsArray(raw, 15)).toEqual(new Uint8Array([1, 0, 1]))
   })
 
   it('extracts channel 23', () => {
     const raw = new Uint32Array([0x800000, 0x000000, 0xffffff])
-    expect(extractSamples(raw, 23)).toEqual(new Uint8Array([1, 0, 1]))
+    expect(extractAsArray(raw, 23)).toEqual(new Uint8Array([1, 0, 1]))
   })
 
   it('returns all zeros for all-zero input', () => {
     const raw = new Uint32Array([0, 0, 0, 0])
-    expect(extractSamples(raw, 0)).toEqual(new Uint8Array([0, 0, 0, 0]))
-    expect(extractSamples(raw, 5)).toEqual(new Uint8Array([0, 0, 0, 0]))
+    expect(extractAsArray(raw, 0)).toEqual(new Uint8Array([0, 0, 0, 0]))
+    expect(extractAsArray(raw, 5)).toEqual(new Uint8Array([0, 0, 0, 0]))
   })
 
   it('returns all ones for channel 0 when all-0xFF input', () => {
     const raw = new Uint32Array([0xff, 0xff, 0xff])
-    expect(extractSamples(raw, 0)).toEqual(new Uint8Array([1, 1, 1]))
+    expect(extractAsArray(raw, 0)).toEqual(new Uint8Array([1, 1, 1]))
   })
 
   it('extracts independent channels from same raw data', () => {
     // Only bit 0 set in all samples
     const raw = new Uint32Array([0x01, 0x01, 0x01])
-    expect(extractSamples(raw, 0)).toEqual(new Uint8Array([1, 1, 1]))
-    expect(extractSamples(raw, 1)).toEqual(new Uint8Array([0, 0, 0]))
+    expect(extractAsArray(raw, 0)).toEqual(new Uint8Array([1, 1, 1]))
+    expect(extractAsArray(raw, 1)).toEqual(new Uint8Array([0, 0, 0]))
   })
 
   it('handles empty input', () => {
     const raw = new Uint32Array(0)
-    expect(extractSamples(raw, 0)).toEqual(new Uint8Array(0))
+    expect(extractAsArray(raw, 0)).toEqual(new Uint8Array(0))
   })
 })
 

--- a/Software/Web/src/core/input/input-manager.js
+++ b/Software/Web/src/core/input/input-manager.js
@@ -1,0 +1,216 @@
+/**
+ * Framework-agnostic input manager for the waveform viewer.
+ *
+ * Maps DOM events to semantic actions via a declarative binding table.
+ * Adding a new input means adding one entry to the BINDINGS array —
+ * no new listeners, no new classes.
+ *
+ * Pure JS — no Vue/Quasar/Pinia imports.
+ */
+
+/**
+ * Returns true if the event target is a text input element.
+ * Used to suppress keyboard shortcuts while the user is typing.
+ * @param {Event} e
+ * @returns {boolean}
+ */
+export function isTyping(e) {
+  const tag = e.target?.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  return e.target?.isContentEditable === true
+}
+
+/**
+ * Default binding table — maps DOM events + modifiers to semantic actions.
+ *
+ * Fields:
+ * - event:          DOM event name
+ * - scope:          which bind() scope this targets ('canvas', 'window', etc.)
+ * - match(e):       predicate — does this binding apply to the event?
+ * - action:         semantic action name dispatched to on() handlers
+ * - payload(e):     extracts a plain payload object from the DOM event
+ * - preventDefault: whether to call e.preventDefault() when matched
+ * - options:        addEventListener options (e.g. { passive: false })
+ *
+ * Array order = priority. First matching binding wins for a given event.
+ */
+export const BINDINGS = [
+  // Shift+Wheel → zoom (primary zoom gesture)
+  {
+    event: 'wheel',
+    scope: 'canvas',
+    match: (e) => e.shiftKey && !e.ctrlKey && !e.metaKey,
+    action: 'zoom',
+    payload: (e) => ({ offsetX: e.offsetX, delta: -e.deltaY }),
+    preventDefault: true,
+    options: { passive: false },
+  },
+
+  // Ctrl/Cmd+Wheel → zoom (pinch-to-zoom on trackpads)
+  {
+    event: 'wheel',
+    scope: 'canvas',
+    match: (e) => e.ctrlKey || e.metaKey,
+    action: 'zoom',
+    payload: (e) => ({ offsetX: e.offsetX, delta: -e.deltaY }),
+    preventDefault: true,
+    options: { passive: false },
+  },
+
+  // Mouse move → cursor tracking
+  {
+    event: 'mousemove',
+    scope: 'canvas',
+    match: () => true,
+    action: 'cursor-move',
+    payload: (e) => ({ offsetX: e.offsetX, offsetY: e.offsetY }),
+    preventDefault: false,
+  },
+
+  // Mouse leave → hide cursor
+  {
+    event: 'mouseleave',
+    scope: 'canvas',
+    match: () => true,
+    action: 'cursor-leave',
+    payload: () => ({}),
+    preventDefault: false,
+  },
+
+  // +/= key → zoom in
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => (e.key === '+' || e.key === '=') && !isTyping(e),
+    action: 'zoom',
+    payload: () => ({ delta: 1 }),
+    preventDefault: true,
+  },
+
+  // - key → zoom out
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === '-' && !isTyping(e),
+    action: 'zoom',
+    payload: () => ({ delta: -1 }),
+    preventDefault: true,
+  },
+]
+
+export class InputManager {
+  constructor(bindings = BINDINGS) {
+    this._bindings = bindings
+    /** @type {Map<string, { element: EventTarget, listeners: Array<{ event: string, handler: Function, options?: object }> }>} */
+    this._scopes = new Map()
+    /** @type {Map<string, Set<Function>>} */
+    this._handlers = new Map()
+  }
+
+  /**
+   * Attach DOM listeners for all bindings targeting the given scope.
+   * @param {EventTarget} element - DOM element or window
+   * @param {string} scope - Scope name (must match binding.scope)
+   */
+  bind(element, scope) {
+    if (this._scopes.has(scope)) {
+      this.unbind(scope)
+    }
+
+    // Group bindings by event name for this scope
+    const eventGroups = new Map()
+    for (const binding of this._bindings) {
+      if (binding.scope !== scope) continue
+      if (!eventGroups.has(binding.event)) {
+        eventGroups.set(binding.event, [])
+      }
+      eventGroups.get(binding.event).push(binding)
+    }
+
+    const listeners = []
+
+    for (const [eventName, scopeBindings] of eventGroups) {
+      // Merge addEventListener options from all bindings for this event
+      let options = undefined
+      for (const b of scopeBindings) {
+        if (b.options) {
+          options = { ...options, ...b.options }
+        }
+      }
+
+      const handler = (e) => {
+        for (const binding of scopeBindings) {
+          if (binding.match(e)) {
+            if (binding.preventDefault) e.preventDefault()
+            const payload = binding.payload(e)
+            this._dispatch(binding.action, payload)
+            return // first match wins
+          }
+        }
+        // No match — event propagates normally
+      }
+
+      element.addEventListener(eventName, handler, options)
+      listeners.push({ event: eventName, handler, options })
+    }
+
+    this._scopes.set(scope, { element, listeners })
+  }
+
+  /**
+   * Remove all listeners for a scope.
+   * @param {string} scope
+   */
+  unbind(scope) {
+    const entry = this._scopes.get(scope)
+    if (!entry) return
+
+    for (const { event, handler, options } of entry.listeners) {
+      entry.element.removeEventListener(event, handler, options)
+    }
+    this._scopes.delete(scope)
+  }
+
+  /**
+   * Register a handler for a semantic action.
+   * @param {string} action
+   * @param {Function} handler
+   */
+  on(action, handler) {
+    if (!this._handlers.has(action)) {
+      this._handlers.set(action, new Set())
+    }
+    this._handlers.get(action).add(handler)
+  }
+
+  /**
+   * Unregister a handler for a semantic action.
+   * @param {string} action
+   * @param {Function} handler
+   */
+  off(action, handler) {
+    const set = this._handlers.get(action)
+    if (set) set.delete(handler)
+  }
+
+  /**
+   * Dispatch a semantic action to all registered handlers.
+   * @param {string} action
+   * @param {object} payload
+   */
+  _dispatch(action, payload) {
+    const set = this._handlers.get(action)
+    if (!set) return
+    for (const handler of set) {
+      handler(payload)
+    }
+  }
+
+  /** Remove all listeners and handlers. */
+  dispose() {
+    for (const scope of [...this._scopes.keys()]) {
+      this.unbind(scope)
+    }
+    this._handlers.clear()
+  }
+}

--- a/Software/Web/src/core/input/input-manager.js
+++ b/Software/Web/src/core/input/input-manager.js
@@ -96,6 +96,66 @@ export const BINDINGS = [
     payload: () => ({ delta: -1 }),
     preventDefault: true,
   },
+
+  // Ctrl+ArrowLeft → scroll left 100% (previous page)
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowLeft' && (e.ctrlKey || e.metaKey) && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: -1.0 }),
+    preventDefault: true,
+  },
+
+  // Ctrl+ArrowRight → scroll right 100% (next page)
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowRight' && (e.ctrlKey || e.metaKey) && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: 1.0 }),
+    preventDefault: true,
+  },
+
+  // Shift+ArrowLeft → scroll left 20%
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowLeft' && e.shiftKey && !e.ctrlKey && !e.metaKey && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: -0.2 }),
+    preventDefault: true,
+  },
+
+  // Shift+ArrowRight → scroll right 20%
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowRight' && e.shiftKey && !e.ctrlKey && !e.metaKey && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: 0.2 }),
+    preventDefault: true,
+  },
+
+  // ArrowLeft → scroll left 5%
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowLeft' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: -0.05 }),
+    preventDefault: true,
+  },
+
+  // ArrowRight → scroll right 5%
+  {
+    event: 'keydown',
+    scope: 'window',
+    match: (e) => e.key === 'ArrowRight' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isTyping(e),
+    action: 'scroll',
+    payload: () => ({ delta: 0.05 }),
+    preventDefault: true,
+  },
 ]
 
 export class InputManager {

--- a/Software/Web/src/core/input/input-manager.test.js
+++ b/Software/Web/src/core/input/input-manager.test.js
@@ -239,6 +239,87 @@ describe('InputManager', () => {
 
       expect(handler).not.toHaveBeenCalled()
     })
+
+    // ── Arrow key scroll bindings ───────────────────────────────────────
+
+    it('dispatches scroll on ArrowLeft', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowLeft', { shiftKey: false, ctrlKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: -0.05 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('dispatches scroll on ArrowRight', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowRight', { shiftKey: false, ctrlKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: 0.05 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('dispatches scroll on Shift+ArrowLeft (20%)', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowLeft', { shiftKey: true, ctrlKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: -0.2 })
+    })
+
+    it('dispatches scroll on Shift+ArrowRight (20%)', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowRight', { shiftKey: true, ctrlKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: 0.2 })
+    })
+
+    it('dispatches scroll on Ctrl+ArrowLeft (100%)', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowLeft', { ctrlKey: true, shiftKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: -1.0 })
+    })
+
+    it('dispatches scroll on Ctrl+ArrowRight (100%)', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowRight', { ctrlKey: true, shiftKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: 1.0 })
+    })
+
+    it('does NOT dispatch arrow scroll when typing in an input', () => {
+      const handler = vi.fn()
+      mgr.on('scroll', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('ArrowLeft', { target: { tagName: 'INPUT' }, shiftKey: false, ctrlKey: false, metaKey: false })
+      win._fire('keydown', event)
+
+      expect(handler).not.toHaveBeenCalled()
+    })
   })
 
   describe('first match wins', () => {

--- a/Software/Web/src/core/input/input-manager.test.js
+++ b/Software/Web/src/core/input/input-manager.test.js
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { InputManager, BINDINGS, isTyping } from './input-manager.js'
+
+// ── isTyping ──────────────────────────────────────────────────────────────────
+
+describe('isTyping', () => {
+  it('returns true for INPUT elements', () => {
+    expect(isTyping({ target: { tagName: 'INPUT' } })).toBe(true)
+  })
+
+  it('returns true for TEXTAREA elements', () => {
+    expect(isTyping({ target: { tagName: 'TEXTAREA' } })).toBe(true)
+  })
+
+  it('returns true for SELECT elements', () => {
+    expect(isTyping({ target: { tagName: 'SELECT' } })).toBe(true)
+  })
+
+  it('returns true for contentEditable elements', () => {
+    expect(isTyping({ target: { tagName: 'DIV', isContentEditable: true } })).toBe(true)
+  })
+
+  it('returns false for non-input elements', () => {
+    expect(isTyping({ target: { tagName: 'CANVAS' } })).toBe(false)
+    expect(isTyping({ target: { tagName: 'DIV' } })).toBe(false)
+  })
+
+  it('returns false when target is null', () => {
+    expect(isTyping({ target: null })).toBe(false)
+  })
+})
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+function createMockElement() {
+  const listeners = new Map()
+  return {
+    addEventListener: vi.fn((event, handler, options) => {
+      if (!listeners.has(event)) listeners.set(event, [])
+      listeners.get(event).push({ handler, options })
+    }),
+    removeEventListener: vi.fn((event, handler) => {
+      const list = listeners.get(event)
+      if (list) {
+        const idx = list.findIndex((l) => l.handler === handler)
+        if (idx >= 0) list.splice(idx, 1)
+      }
+    }),
+    _listeners: listeners,
+    _fire(event, eventObj) {
+      const list = listeners.get(event) || []
+      for (const { handler } of list) handler(eventObj)
+    },
+  }
+}
+
+function createWheelEvent(overrides = {}) {
+  return {
+    type: 'wheel',
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    deltaY: -100,
+    offsetX: 400,
+    offsetY: 200,
+    preventDefault: vi.fn(),
+    ...overrides,
+  }
+}
+
+function createKeyEvent(key, overrides = {}) {
+  return {
+    type: 'keydown',
+    key,
+    target: { tagName: 'CANVAS' },
+    preventDefault: vi.fn(),
+    ...overrides,
+  }
+}
+
+function createMouseEvent(type, overrides = {}) {
+  return {
+    type,
+    offsetX: 400,
+    offsetY: 200,
+    preventDefault: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ── InputManager ──────────────────────────────────────────────────────────────
+
+describe('InputManager', () => {
+  let mgr, canvas, win
+
+  beforeEach(() => {
+    mgr = new InputManager()
+    canvas = createMockElement()
+    win = createMockElement()
+  })
+
+  describe('bind / unbind', () => {
+    it('attaches listeners to the element', () => {
+      mgr.bind(canvas, 'canvas')
+      // Should have listeners for wheel, mousemove, mouseleave
+      expect(canvas.addEventListener).toHaveBeenCalled()
+      const events = canvas.addEventListener.mock.calls.map((c) => c[0])
+      expect(events).toContain('wheel')
+      expect(events).toContain('mousemove')
+      expect(events).toContain('mouseleave')
+    })
+
+    it('attaches window listeners for keydown', () => {
+      mgr.bind(win, 'window')
+      const events = win.addEventListener.mock.calls.map((c) => c[0])
+      expect(events).toContain('keydown')
+    })
+
+    it('removes listeners on unbind', () => {
+      mgr.bind(canvas, 'canvas')
+      const addCount = canvas.addEventListener.mock.calls.length
+      mgr.unbind('canvas')
+      expect(canvas.removeEventListener).toHaveBeenCalledTimes(addCount)
+    })
+
+    it('unbind is idempotent for unknown scope', () => {
+      expect(() => mgr.unbind('nonexistent')).not.toThrow()
+    })
+
+    it('re-binding a scope unbinds the old one first', () => {
+      mgr.bind(canvas, 'canvas')
+      const firstAddCount = canvas.addEventListener.mock.calls.length
+      mgr.bind(canvas, 'canvas')
+      expect(canvas.removeEventListener).toHaveBeenCalledTimes(firstAddCount)
+    })
+  })
+
+  describe('action dispatch', () => {
+    it('dispatches zoom action on Shift+Wheel', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+
+      const event = createWheelEvent({ shiftKey: true, deltaY: -100, offsetX: 300 })
+      canvas._fire('wheel', event)
+
+      expect(handler).toHaveBeenCalledWith({ offsetX: 300, delta: 100 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('dispatches zoom action on Ctrl+Wheel', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+
+      const event = createWheelEvent({ ctrlKey: true, deltaY: 50, offsetX: 200 })
+      canvas._fire('wheel', event)
+
+      expect(handler).toHaveBeenCalledWith({ offsetX: 200, delta: -50 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('does NOT dispatch on bare wheel (no modifiers)', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+
+      const event = createWheelEvent({ shiftKey: false, ctrlKey: false, metaKey: false })
+      canvas._fire('wheel', event)
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('dispatches cursor-move on mousemove', () => {
+      const handler = vi.fn()
+      mgr.on('cursor-move', handler)
+      mgr.bind(canvas, 'canvas')
+
+      const event = createMouseEvent('mousemove', { offsetX: 150, offsetY: 75 })
+      canvas._fire('mousemove', event)
+
+      expect(handler).toHaveBeenCalledWith({ offsetX: 150, offsetY: 75 })
+    })
+
+    it('dispatches cursor-leave on mouseleave', () => {
+      const handler = vi.fn()
+      mgr.on('cursor-leave', handler)
+      mgr.bind(canvas, 'canvas')
+
+      const event = createMouseEvent('mouseleave')
+      canvas._fire('mouseleave', event)
+
+      expect(handler).toHaveBeenCalledWith({})
+    })
+
+    it('dispatches zoom on + key', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('+')
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: 1 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('dispatches zoom on = key', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('=')
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: 1 })
+    })
+
+    it('dispatches zoom on - key', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('-')
+      win._fire('keydown', event)
+
+      expect(handler).toHaveBeenCalledWith({ delta: -1 })
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('does NOT dispatch keyboard zoom when typing in an input', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(win, 'window')
+
+      const event = createKeyEvent('+', { target: { tagName: 'INPUT' } })
+      win._fire('keydown', event)
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('first match wins', () => {
+    it('Shift+Ctrl+Wheel matches Shift binding first', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+
+      // Both shiftKey and ctrlKey set — Shift binding is first in the array
+      const event = createWheelEvent({ shiftKey: true, ctrlKey: true })
+      canvas._fire('wheel', event)
+
+      // Should fire exactly once (not twice)
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('multiple handlers', () => {
+    it('calls all handlers for the same action', () => {
+      const h1 = vi.fn()
+      const h2 = vi.fn()
+      mgr.on('zoom', h1)
+      mgr.on('zoom', h2)
+      mgr.bind(canvas, 'canvas')
+
+      canvas._fire('wheel', createWheelEvent({ shiftKey: true }))
+
+      expect(h1).toHaveBeenCalledTimes(1)
+      expect(h2).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('off', () => {
+    it('unregisters a handler', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.off('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+
+      canvas._fire('wheel', createWheelEvent({ shiftKey: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('off on unknown action does not throw', () => {
+      expect(() => mgr.off('nonexistent', vi.fn())).not.toThrow()
+    })
+  })
+
+  describe('dispose', () => {
+    it('removes all listeners and clears handlers', () => {
+      const handler = vi.fn()
+      mgr.on('zoom', handler)
+      mgr.bind(canvas, 'canvas')
+      mgr.bind(win, 'window')
+
+      mgr.dispose()
+
+      expect(canvas.removeEventListener).toHaveBeenCalled()
+      expect(win.removeEventListener).toHaveBeenCalled()
+
+      // Firing events after dispose should not call handlers
+      canvas._fire('wheel', createWheelEvent({ shiftKey: true }))
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('custom bindings', () => {
+    it('works with a custom binding table', () => {
+      const customBindings = [
+        {
+          event: 'click',
+          scope: 'canvas',
+          match: () => true,
+          action: 'place-marker',
+          payload: (e) => ({ x: e.offsetX }),
+          preventDefault: false,
+        },
+      ]
+      const customMgr = new InputManager(customBindings)
+      const handler = vi.fn()
+      customMgr.on('place-marker', handler)
+      customMgr.bind(canvas, 'canvas')
+
+      canvas._fire('click', { offsetX: 42, preventDefault: vi.fn() })
+
+      expect(handler).toHaveBeenCalledWith({ x: 42 })
+      customMgr.dispose()
+    })
+  })
+})
+
+// ── BINDINGS table sanity ─────────────────────────────────────────────────────
+
+describe('BINDINGS', () => {
+  it('every binding has required fields', () => {
+    for (const b of BINDINGS) {
+      expect(b).toHaveProperty('event')
+      expect(b).toHaveProperty('scope')
+      expect(b).toHaveProperty('match')
+      expect(b).toHaveProperty('action')
+      expect(b).toHaveProperty('payload')
+      expect(typeof b.match).toBe('function')
+      expect(typeof b.payload).toBe('function')
+      expect(typeof b.preventDefault).toBe('boolean')
+    }
+  })
+
+  it('has canvas and window scopes', () => {
+    const scopes = new Set(BINDINGS.map((b) => b.scope))
+    expect(scopes.has('canvas')).toBe(true)
+    expect(scopes.has('window')).toBe(true)
+  })
+})

--- a/Software/Web/src/core/renderer/colors.js
+++ b/Software/Web/src/core/renderer/colors.js
@@ -47,6 +47,10 @@ export const COLORS = {
   timelineBackground: 'rgb(28,28,28)',
   timelineTick: 'rgba(255,255,255,0.7)',
   cursorLine: 'rgba(255, 255, 255, 0.5)',
+  minimapBackground: 'rgb(20,20,20)',
+  minimapViewportFill: 'rgba(255,255,255,0.12)',
+  minimapViewportStroke: 'rgba(255,255,255,0.5)',
+  minimapDimOverlay: 'rgba(0,0,0,0.4)',
 }
 
 /**

--- a/Software/Web/src/core/renderer/colors.js
+++ b/Software/Web/src/core/renderer/colors.js
@@ -46,6 +46,7 @@ export const COLORS = {
   dataLossFill: 'rgba(140, 30, 30, 0.35)',
   timelineBackground: 'rgb(28,28,28)',
   timelineTick: 'rgba(255,255,255,0.7)',
+  cursorLine: 'rgba(255, 255, 255, 0.5)',
 }
 
 /**

--- a/Software/Web/src/core/renderer/minimap-renderer.js
+++ b/Software/Web/src/core/renderer/minimap-renderer.js
@@ -1,0 +1,190 @@
+/**
+ * Canvas 2D minimap renderer for the logic analyzer.
+ *
+ * Draws a compressed overview of all visible channel waveforms across the
+ * entire capture/stream, with a draggable viewport rectangle overlay showing
+ * the currently visible portion.
+ *
+ * Uses the same column-summary decimation as WaveformRenderer — including
+ * SampleBuffer's pre-decimated pyramid levels — so rendering is O(pixelCount)
+ * regardless of total sample count.
+ */
+
+import { getChannelColor, withAlpha, COLORS } from './colors.js'
+import { SampleBuffer } from '../sample-buffer.js'
+import { computeColumnSummary } from './waveform-renderer.js'
+
+/** Minimum viewport rectangle width in CSS pixels. */
+const MIN_VIEWPORT_WIDTH = 4
+
+/** Alpha for high-state channel pixels. */
+const CHANNEL_ALPHA = 0.8
+
+/** Alpha for mixed-state channel pixels. */
+const MIXED_ALPHA = 0.4
+
+export class MinimapRenderer {
+  /**
+   * @param {HTMLCanvasElement} canvas
+   */
+  constructor(canvas) {
+    this.canvas = canvas
+    this.ctx = canvas.getContext('2d')
+
+    this.channels = []
+    this.totalSamples = 0
+    this.firstSample = 0
+    this.visibleSamples = 100
+
+    this._width = 0
+    this._height = 0
+    this._dpr = 1
+    this._visibleChannels = []
+  }
+
+  // ── Data setters ────────────────────────────────────────────────────────
+
+  setChannels(channels) {
+    this.channels = channels
+    this._visibleChannels = channels.filter((ch) => ch.visible !== false)
+  }
+
+  setTotalSamples(total) {
+    this.totalSamples = Math.max(0, total)
+  }
+
+  setViewport(firstSample, visibleSamples) {
+    this.firstSample = firstSample
+    this.visibleSamples = Math.max(1, visibleSamples)
+  }
+
+  // ── Layout ──────────────────────────────────────────────────────────────
+
+  resize() {
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+    const rect = this.canvas.getBoundingClientRect()
+    this.canvas.width = Math.round(rect.width * dpr)
+    this.canvas.height = Math.round(rect.height * dpr)
+    this._dpr = dpr
+    this._width = rect.width
+    this._height = rect.height
+  }
+
+  // ── Coordinate helpers ──────────────────────────────────────────────────
+
+  /** Convert CSS pixel x to sample index across the full data range. */
+  sampleAtX(x) {
+    if (this._width === 0 || this.totalSamples === 0) return 0
+    return Math.floor((x / this._width) * this.totalSamples)
+  }
+
+  /** Get the viewport rectangle bounds in CSS pixels. */
+  getViewportRect() {
+    if (this.totalSamples === 0) return { x: 0, width: 0 }
+    const x = (this.firstSample / this.totalSamples) * this._width
+    const w = Math.max(MIN_VIEWPORT_WIDTH, (this.visibleSamples / this.totalSamples) * this._width)
+    return { x, width: w }
+  }
+
+  /** Check whether a CSS pixel x coordinate is inside the viewport rectangle. */
+  isInsideViewport(px) {
+    const rect = this.getViewportRect()
+    return px >= rect.x && px <= rect.x + rect.width
+  }
+
+  // ── Main render ─────────────────────────────────────────────────────────
+
+  render() {
+    const { ctx } = this
+    const width = this._width
+    const height = this._height
+    const dpr = this._dpr
+
+    if (width === 0 || height === 0) return
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+    // Background
+    ctx.fillStyle = COLORS.minimapBackground
+    ctx.fillRect(0, 0, width, height)
+
+    const channels = this._visibleChannels
+    if (channels.length === 0 || this.totalSamples === 0) return
+
+    // Draw channel waveforms
+    this._drawChannels(ctx, channels, width, height)
+
+    // Draw viewport overlay
+    this._drawViewport(ctx, width, height)
+  }
+
+  // ── Render layers ───────────────────────────────────────────────────────
+
+  _drawChannels(ctx, channels, width, height) {
+    const bandHeight = height / channels.length
+    const samplesPerPixel = this.totalSamples / width
+    const pixelCount = Math.ceil(width)
+
+    for (let i = 0; i < channels.length; i++) {
+      const channel = channels[i]
+      const samples = channel.samples
+      if (!samples || samples.length === 0) continue
+
+      const yTop = i * bandHeight
+      const color = getChannelColor(channel)
+
+      const summary =
+        samples instanceof SampleBuffer
+          ? samples.getColumnSummary(0, samplesPerPixel, pixelCount)
+          : computeColumnSummary(samples, 0, samplesPerPixel, pixelCount)
+
+      // Draw high pixels
+      ctx.fillStyle = withAlpha(color, CHANNEL_ALPHA)
+      for (let px = 0; px < pixelCount; px++) {
+        if (summary[px] === 1) {
+          ctx.fillRect(px, yTop, 1, bandHeight)
+        }
+      }
+
+      // Draw mixed pixels at lower alpha
+      ctx.fillStyle = withAlpha(color, MIXED_ALPHA)
+      for (let px = 0; px < pixelCount; px++) {
+        if (summary[px] === 2) {
+          ctx.fillRect(px, yTop, 1, bandHeight)
+        }
+      }
+    }
+  }
+
+  _drawViewport(ctx, width, height) {
+    const rect = this.getViewportRect()
+    if (rect.width === 0) return
+
+    // Dim areas outside viewport
+    ctx.fillStyle = COLORS.minimapDimOverlay
+    if (rect.x > 0) {
+      ctx.fillRect(0, 0, rect.x, height)
+    }
+    const rightEdge = rect.x + rect.width
+    if (rightEdge < width) {
+      ctx.fillRect(rightEdge, 0, width - rightEdge, height)
+    }
+
+    // Viewport rectangle fill
+    ctx.fillStyle = COLORS.minimapViewportFill
+    ctx.fillRect(rect.x, 0, rect.width, height)
+
+    // Viewport rectangle border
+    ctx.strokeStyle = COLORS.minimapViewportStroke
+    ctx.lineWidth = 1
+    ctx.strokeRect(Math.round(rect.x) + 0.5, 0.5, Math.round(rect.width) - 1, height - 1)
+  }
+
+  /** Release resources. */
+  dispose() {
+    this.channels = []
+    this._visibleChannels = []
+    this.canvas = null
+    this.ctx = null
+  }
+}

--- a/Software/Web/src/core/renderer/minimap-renderer.test.js
+++ b/Software/Web/src/core/renderer/minimap-renderer.test.js
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MinimapRenderer } from './minimap-renderer.js'
+
+// ── Mock canvas helper ────────────────────────────────────────────────────────
+
+function createMockCanvas(width = 300, height = 24) {
+  const ops = []
+  const ctx = {
+    setTransform: (...args) => ops.push(['setTransform', ...args]),
+    clearRect: (...args) => ops.push(['clearRect', ...args]),
+    fillRect: (...args) => ops.push(['fillRect', ...args]),
+    strokeRect: (...args) => ops.push(['strokeRect', ...args]),
+    beginPath: () => ops.push(['beginPath']),
+    moveTo: (...args) => ops.push(['moveTo', ...args]),
+    lineTo: (...args) => ops.push(['lineTo', ...args]),
+    stroke: () => ops.push(['stroke']),
+    fill: () => ops.push(['fill']),
+    closePath: () => ops.push(['closePath']),
+    save: () => ops.push(['save']),
+    restore: () => ops.push(['restore']),
+    rect: () => {},
+    clip: () => {},
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    globalAlpha: 1,
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    fillText: () => {},
+    setLineDash: () => {},
+  }
+  const canvas = {
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width, height }),
+    width: 0,
+    height: 0,
+  }
+  return { canvas, ctx, ops }
+}
+
+// ── Constructor + resize ──────────────────────────────────────────────────────
+
+describe('MinimapRenderer', () => {
+  let renderer, canvas
+
+  beforeEach(() => {
+    const mock = createMockCanvas(400, 24)
+    canvas = mock.canvas
+    renderer = new MinimapRenderer(canvas)
+    renderer.resize()
+  })
+
+  it('stores canvas dimensions after resize', () => {
+    expect(renderer._width).toBe(400)
+    expect(renderer._height).toBe(24)
+    expect(renderer._dpr).toBeGreaterThan(0)
+  })
+
+  // ── Data setters ────────────────────────────────────────────────────────
+
+  describe('setChannels', () => {
+    it('filters hidden channels', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1]) },
+        { channelNumber: 1, visible: false, samples: new Uint8Array([1]) },
+        { channelNumber: 2, visible: true, samples: new Uint8Array([0]) },
+      ])
+      expect(renderer._visibleChannels.length).toBe(2)
+      expect(renderer._visibleChannels[0].channelNumber).toBe(0)
+      expect(renderer._visibleChannels[1].channelNumber).toBe(2)
+    })
+  })
+
+  describe('setTotalSamples', () => {
+    it('stores total samples', () => {
+      renderer.setTotalSamples(1000)
+      expect(renderer.totalSamples).toBe(1000)
+    })
+
+    it('clamps negative to zero', () => {
+      renderer.setTotalSamples(-5)
+      expect(renderer.totalSamples).toBe(0)
+    })
+  })
+
+  describe('setViewport', () => {
+    it('stores viewport values', () => {
+      renderer.setViewport(100, 50)
+      expect(renderer.firstSample).toBe(100)
+      expect(renderer.visibleSamples).toBe(50)
+    })
+
+    it('clamps visibleSamples to minimum 1', () => {
+      renderer.setViewport(0, 0)
+      expect(renderer.visibleSamples).toBe(1)
+    })
+  })
+
+  // ── Coordinate helpers ──────────────────────────────────────────────────
+
+  describe('sampleAtX', () => {
+    it('converts pixel to sample index', () => {
+      renderer.setTotalSamples(1000)
+      // 400px wide, 1000 total → 2.5 samples per pixel
+      expect(renderer.sampleAtX(0)).toBe(0)
+      expect(renderer.sampleAtX(200)).toBe(500)
+      expect(renderer.sampleAtX(400)).toBe(1000)
+    })
+
+    it('returns 0 when no data', () => {
+      renderer.setTotalSamples(0)
+      expect(renderer.sampleAtX(100)).toBe(0)
+    })
+
+    it('returns 0 when width is 0', () => {
+      const mock = createMockCanvas(0, 24)
+      const r = new MinimapRenderer(mock.canvas)
+      r.resize()
+      r.setTotalSamples(1000)
+      expect(r.sampleAtX(0)).toBe(0)
+    })
+  })
+
+  describe('getViewportRect', () => {
+    it('returns correct bounds', () => {
+      renderer.setTotalSamples(1000)
+      renderer.setViewport(250, 500) // 25%-75% of data
+      const rect = renderer.getViewportRect()
+      // x = 250/1000 * 400 = 100
+      expect(rect.x).toBe(100)
+      // width = 500/1000 * 400 = 200
+      expect(rect.width).toBe(200)
+    })
+
+    it('clamps width to minimum', () => {
+      renderer.setTotalSamples(1000000)
+      renderer.setViewport(0, 10) // tiny viewport
+      const rect = renderer.getViewportRect()
+      // Natural width = 10/1000000 * 400 ≈ 0.004 → clamped to 4
+      expect(rect.width).toBe(4)
+    })
+
+    it('returns zero-width rect when no data', () => {
+      renderer.setTotalSamples(0)
+      const rect = renderer.getViewportRect()
+      expect(rect.x).toBe(0)
+      expect(rect.width).toBe(0)
+    })
+  })
+
+  describe('isInsideViewport', () => {
+    it('returns true for click inside viewport rect', () => {
+      renderer.setTotalSamples(1000)
+      renderer.setViewport(250, 500) // rect at x=100, width=200
+      expect(renderer.isInsideViewport(150)).toBe(true)
+      expect(renderer.isInsideViewport(100)).toBe(true) // left edge
+      expect(renderer.isInsideViewport(300)).toBe(true) // right edge
+    })
+
+    it('returns false for click outside viewport rect', () => {
+      renderer.setTotalSamples(1000)
+      renderer.setViewport(250, 500) // rect at x=100, width=200
+      expect(renderer.isInsideViewport(50)).toBe(false)
+      expect(renderer.isInsideViewport(350)).toBe(false)
+    })
+  })
+
+  // ── Render safety ───────────────────────────────────────────────────────
+
+  describe('render', () => {
+    it('does not throw with no channels', () => {
+      renderer.setChannels([])
+      renderer.setTotalSamples(1000)
+      renderer.setViewport(0, 100)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw with totalSamples=0', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1, 0, 1]) },
+      ])
+      renderer.setTotalSamples(0)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw with empty samples', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array(0) },
+      ])
+      renderer.setTotalSamples(100)
+      renderer.setViewport(0, 50)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw with single channel', () => {
+      const samples = new Uint8Array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+      renderer.setChannels([{ channelNumber: 0, visible: true, samples }])
+      renderer.setTotalSamples(10)
+      renderer.setViewport(0, 10)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw with multiple channels', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1, 0, 1, 0, 1]) },
+        { channelNumber: 1, visible: true, samples: new Uint8Array([0, 1, 0, 1, 0]) },
+        { channelNumber: 2, visible: true, samples: new Uint8Array([1, 1, 0, 0, 1]) },
+      ])
+      renderer.setTotalSamples(5)
+      renderer.setViewport(0, 5)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw with viewport at end of data', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1, 0, 1, 0, 1]) },
+      ])
+      renderer.setTotalSamples(5)
+      renderer.setViewport(3, 2) // last 2 samples
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw on zero-sized canvas', () => {
+      const mock = createMockCanvas(0, 0)
+      const r = new MinimapRenderer(mock.canvas)
+      r.resize()
+      r.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1, 0]) },
+      ])
+      r.setTotalSamples(2)
+      expect(() => r.render()).not.toThrow()
+    })
+  })
+
+  // ── Dispose ─────────────────────────────────────────────────────────────
+
+  describe('dispose', () => {
+    it('clears references', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array([1]) },
+      ])
+      renderer.dispose()
+      expect(renderer.channels).toEqual([])
+      expect(renderer._visibleChannels).toEqual([])
+      expect(renderer.canvas).toBeNull()
+      expect(renderer.ctx).toBeNull()
+    })
+  })
+})

--- a/Software/Web/src/core/renderer/timeline-renderer.js
+++ b/Software/Web/src/core/renderer/timeline-renderer.js
@@ -121,6 +121,10 @@ export class TimelineRenderer {
     // Start at the first aligned tick before the viewport
     const firstTick = Math.ceil(this.firstSample / interval) * interval
 
+    // When individual samples are visible, offset ticks to sample centers
+    // so they align with the waveform grid lines and cursor.
+    const centerOffset = sampleWidth >= 1 ? sampleWidth / 2 : 0
+
     // Draw minor ticks first (behind major)
     if (minorInterval > 0) {
       const firstMinor = Math.ceil(this.firstSample / minorInterval) * minorInterval
@@ -129,7 +133,7 @@ export class TimelineRenderer {
       ctx.globalAlpha = 0.3
       ctx.beginPath()
       for (let s = firstMinor; s < this.firstSample + this.visibleSamples; s += minorInterval) {
-        const x = Math.round((s - this.firstSample) * sampleWidth) + 0.5
+        const x = Math.round((s - this.firstSample) * sampleWidth + centerOffset) + 0.5
         ctx.moveTo(x, height * 0.65)
         ctx.lineTo(x, height)
       }
@@ -151,7 +155,7 @@ export class TimelineRenderer {
     const lastSample = this.firstSample + this.visibleSamples
 
     for (let s = firstTick; s < lastSample; s += interval) {
-      const x = Math.round((s - this.firstSample) * sampleWidth) + 0.5
+      const x = Math.round((s - this.firstSample) * sampleWidth + centerOffset) + 0.5
 
       // Tick line
       ctx.moveTo(x, tickTop)

--- a/Software/Web/src/core/renderer/waveform-renderer.js
+++ b/Software/Web/src/core/renderer/waveform-renderer.js
@@ -15,6 +15,7 @@
  */
 
 import { getChannelColor, withAlpha, BG_CHANNEL_COLORS, COLORS } from './colors.js'
+import { SampleBuffer } from '../sample-buffer.js'
 
 /** Minimum height per channel in CSS pixels. */
 export const MIN_CHANNEL_HEIGHT = 30
@@ -286,9 +287,9 @@ export class WaveformRenderer {
       const color = getChannelColor(channel)
 
       if (samplesPerPixel <= 2) {
-        this._drawChannelDetailed(ctx, samples, yHi, yLo, width, color)
+        this._drawChannelDetailed(ctx, channel, yHi, yLo, width, color)
       } else {
-        this._drawChannelDecimated(ctx, samples, yHi, yLo, width, color, samplesPerPixel)
+        this._drawChannelDecimated(ctx, channel, yHi, yLo, width, color, samplesPerPixel)
       }
     }
   }
@@ -298,18 +299,22 @@ export class WaveformRenderer {
    * Used when zoomed in (<=2 samples per pixel).
    * Draws fill + signal line in two passes through the data.
    */
-  _drawChannelDetailed(ctx, samples, yHi, yLo, width, color) {
+  _drawChannelDetailed(ctx, channel, yHi, yLo, width, color) {
+    const samples = channel.samples
+    const isSampleBuffer = samples instanceof SampleBuffer
+    const totalLen = isSampleBuffer ? samples.length : samples.length
     const { firstSample, visibleSamples } = this
-    const lastSample = Math.min(firstSample + visibleSamples, samples.length)
-    if (firstSample >= samples.length) return
+    const lastSample = Math.min(firstSample + visibleSamples, totalLen)
+    if (firstSample >= totalLen) return
 
     const sampleWidth = width / visibleSamples
     const endX = (lastSample - firstSample) * sampleWidth
+    const getSample = isSampleBuffer ? (i) => samples.get(i) : (i) => samples[i]
 
     // Pass 1: fill — trace waveform then close along baseline
     ctx.fillStyle = withAlpha(color, FILL_ALPHA)
     ctx.beginPath()
-    this._traceWaveform(ctx, samples, firstSample, lastSample, sampleWidth, yHi, yLo)
+    this._traceWaveform(ctx, getSample, firstSample, lastSample, sampleWidth, yHi, yLo)
     ctx.lineTo(endX, yLo)
     ctx.lineTo(0, yLo)
     ctx.closePath()
@@ -319,7 +324,7 @@ export class WaveformRenderer {
     ctx.strokeStyle = color
     ctx.lineWidth = SIGNAL_LINE_WIDTH
     ctx.beginPath()
-    this._traceWaveform(ctx, samples, firstSample, lastSample, sampleWidth, yHi, yLo)
+    this._traceWaveform(ctx, getSample, firstSample, lastSample, sampleWidth, yHi, yLo)
     ctx.stroke()
   }
 
@@ -328,16 +333,24 @@ export class WaveformRenderer {
    * Uses RLE: only emits lineTo at transitions.
    * Draws slanted transitions so it's easy to see exactly between
    * which two samples a value change occurred.
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {function(number): number} getSample - function returning 0/1 at index
+   * @param {number} firstSample
+   * @param {number} lastSample
+   * @param {number} sampleWidth
+   * @param {number} yHi
+   * @param {number} yLo
    */
-  _traceWaveform(ctx, samples, firstSample, lastSample, sampleWidth, yHi, yLo) {
+  _traceWaveform(ctx, getSample, firstSample, lastSample, sampleWidth, yHi, yLo) {
     const slantHalf = Math.min(sampleWidth * 0.15, 4)
 
-    let currentValue = samples[firstSample]
+    let currentValue = getSample(firstSample)
     let currentY = currentValue ? yHi : yLo
     ctx.moveTo(0, currentY)
 
     for (let i = firstSample + 1; i < lastSample; i++) {
-      const val = samples[i]
+      const val = getSample(i)
       if (val !== currentValue) {
         const x = (i - firstSample) * sampleWidth
         ctx.lineTo(x - slantHalf, currentY)
@@ -354,10 +367,14 @@ export class WaveformRenderer {
    * Decimated rendering: per-pixel-column min/max summary.
    * Used when zoomed out (>2 samples per pixel).
    */
-  _drawChannelDecimated(ctx, samples, yHi, yLo, width, color, samplesPerPixel) {
+  _drawChannelDecimated(ctx, channel, yHi, yLo, width, color, samplesPerPixel) {
+    const samples = channel.samples
     const { firstSample } = this
     const pixelCount = Math.ceil(width)
-    const summary = computeColumnSummary(samples, firstSample, samplesPerPixel, pixelCount)
+    const summary =
+      samples instanceof SampleBuffer
+        ? samples.getColumnSummary(firstSample, samplesPerPixel, pixelCount)
+        : computeColumnSummary(samples, firstSample, samplesPerPixel, pixelCount)
 
     // Pass 1: fill — batch adjacent high/mixed columns into single fillRect calls
     ctx.fillStyle = withAlpha(color, FILL_ALPHA)

--- a/Software/Web/src/core/renderer/waveform-renderer.js
+++ b/Software/Web/src/core/renderer/waveform-renderer.js
@@ -90,6 +90,7 @@ export class WaveformRenderer {
     this.userMarker = null
     this.regions = []
     this.bursts = []
+    this.cursorX = null
 
     // Layout cache (CSS pixels)
     this._width = 0
@@ -131,6 +132,11 @@ export class WaveformRenderer {
   /** Set the burst marker sample indices array. */
   setBursts(bursts) {
     this.bursts = bursts
+  }
+
+  /** Set the cursor line position (CSS pixels), or null to hide. */
+  setCursorX(x) {
+    this.cursorX = x
   }
 
   // ── Layout ─────────────────────────────────────────────────────────────
@@ -220,6 +226,7 @@ export class WaveformRenderer {
     this._drawTriggerMarker(ctx, totalHeight)
     this._drawBurstMarkers(ctx, totalHeight)
     this._drawUserMarker(ctx, totalHeight)
+    this._drawCursorLine(ctx, totalHeight)
 
     ctx.restore()
   }
@@ -477,6 +484,19 @@ export class WaveformRenderer {
     ctx.lineTo(Math.round(x) + 0.5, totalHeight)
     ctx.stroke()
     ctx.setLineDash([])
+  }
+
+  _drawCursorLine(ctx, totalHeight) {
+    if (this.cursorX == null) return
+    const x = Math.round(this.cursorX) + 0.5
+    if (x < 0 || x > this._width) return
+
+    ctx.strokeStyle = COLORS.cursorLine
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x, totalHeight)
+    ctx.stroke()
   }
 
   /** Release resources. */

--- a/Software/Web/src/core/renderer/waveform-renderer.test.js
+++ b/Software/Web/src/core/renderer/waveform-renderer.test.js
@@ -318,6 +318,43 @@ describe('WaveformRenderer', () => {
     })
   })
 
+  describe('setCursorX', () => {
+    it('stores cursor position', () => {
+      renderer.setCursorX(200.5)
+      expect(renderer.cursorX).toBe(200.5)
+    })
+
+    it('accepts null to hide cursor', () => {
+      renderer.setCursorX(200)
+      renderer.setCursorX(null)
+      expect(renderer.cursorX).toBeNull()
+    })
+  })
+
+  describe('cursor line rendering', () => {
+    it('does not throw when cursor is set', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array(100) },
+      ])
+      renderer.setViewport(0, 100)
+      renderer.setCursorX(400)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('does not throw when cursor is null', () => {
+      renderer.setChannels([
+        { channelNumber: 0, visible: true, samples: new Uint8Array(100) },
+      ])
+      renderer.setViewport(0, 100)
+      renderer.setCursorX(null)
+      expect(() => renderer.render()).not.toThrow()
+    })
+
+    it('initializes cursorX as null', () => {
+      expect(renderer.cursorX).toBeNull()
+    })
+  })
+
   describe('dispose', () => {
     it('clears all references', () => {
       renderer.setChannels([{ channelNumber: 0, visible: true, samples: new Uint8Array(10) }])

--- a/Software/Web/src/core/sample-buffer.js
+++ b/Software/Web/src/core/sample-buffer.js
@@ -1,0 +1,373 @@
+/**
+ * Ring buffer with multi-level decimation pyramid for logic analyzer sample data.
+ *
+ * Provides O(1) append (no full-buffer copies) and O(1) per-pixel summary lookups
+ * at any zoom level via pre-computed decimation levels.
+ *
+ * Framework-agnostic — no Vue/Quasar imports.
+ */
+
+/** Decimation factor per level — each level aggregates 10 entries from the previous. */
+const DECIMATION_FACTOR = 10
+
+/** Number of decimation pyramid levels (10x, 100x, 1000x, 10000x). */
+const PYRAMID_LEVELS = 4
+
+/** Cumulative factors for each pyramid level. */
+const LEVEL_FACTORS = [10, 100, 1000, 10000]
+
+/**
+ * Decimation encoding (stored in pyramid Uint8Arrays):
+ *   bit 0 = hasLow  (at least one sample in the group was 0)
+ *   bit 1 = hasHigh (at least one sample in the group was 1)
+ *
+ * Possible values: 1 = all low, 2 = all high, 3 = mixed (both)
+ */
+const HAS_LOW = 1
+const HAS_HIGH = 2
+
+export class SampleBuffer {
+  /**
+   * @param {number} capacity - Maximum number of raw samples
+   * @param {{ ring?: boolean }} [options]
+   */
+  constructor(capacity, { ring = true } = {}) {
+    this._capacity = capacity
+    this._ring = ring
+    this._data = new Uint8Array(capacity)
+    this._head = 0
+    this._length = 0
+    this._totalAppended = 0
+
+    // Decimation pyramid — each level is a mini ring buffer
+    this._pyramid = new Array(PYRAMID_LEVELS)
+    this._accumulators = new Array(PYRAMID_LEVELS)
+
+    for (let level = 0; level < PYRAMID_LEVELS; level++) {
+      const levelCapacity = Math.ceil(capacity / LEVEL_FACTORS[level])
+      this._pyramid[level] = {
+        data: new Uint8Array(levelCapacity),
+        capacity: levelCapacity,
+        head: 0,
+        length: 0,
+      }
+      this._accumulators[level] = { hasLow: false, hasHigh: false, count: 0 }
+    }
+  }
+
+  /**
+   * Creates a flat (non-ring) SampleBuffer from an existing Uint8Array.
+   * Builds the full decimation pyramid in one pass.
+   *
+   * @param {Uint8Array} data - Raw 0/1 sample data
+   * @returns {SampleBuffer}
+   */
+  static fromUint8Array(data) {
+    const buffer = new SampleBuffer(data.length, { ring: false })
+    buffer.append(data)
+    return buffer
+  }
+
+  /** Number of valid samples currently stored. */
+  get length() {
+    return this._length
+  }
+
+  /** Total capacity of the raw sample buffer. */
+  get capacity() {
+    return this._capacity
+  }
+
+  /**
+   * Read a sample by logical index (0 = oldest stored sample).
+   * @param {number} index
+   * @returns {number} 0 or 1
+   */
+  get(index) {
+    return this._data[(this._head + index) % this._capacity]
+  }
+
+  /**
+   * Append a chunk of samples. In ring mode, old samples are discarded
+   * when capacity is exceeded. In flat mode, appending beyond capacity throws.
+   *
+   * @param {Uint8Array} chunk - 0/1 sample values to append
+   */
+  append(chunk) {
+    const chunkLen = chunk.length
+    if (chunkLen === 0) return
+
+    if (!this._ring && this._length + chunkLen > this._capacity) {
+      throw new Error(
+        `SampleBuffer: flat buffer overflow (${this._length} + ${chunkLen} > ${this._capacity})`,
+      )
+    }
+
+    // Feed all samples into the decimation pyramid (must happen before any trimming)
+    for (let i = 0; i < chunkLen; i++) {
+      this._feedSample(chunk[i])
+    }
+
+    // If chunk is larger than capacity, only write the tail that fits
+    let writeChunk = chunk
+    let writeLen = chunkLen
+    if (chunkLen >= this._capacity) {
+      writeChunk = chunk.subarray(chunkLen - this._capacity)
+      writeLen = this._capacity
+    }
+
+    // Write position in the circular buffer
+    const writePos = (this._head + this._length) % this._capacity
+
+    // Write chunk into ring buffer, handling wrap-around
+    const spaceToEnd = this._capacity - writePos
+    if (writeLen <= spaceToEnd) {
+      this._data.set(writeChunk, writePos)
+    } else {
+      this._data.set(writeChunk.subarray(0, spaceToEnd), writePos)
+      this._data.set(writeChunk.subarray(spaceToEnd), 0)
+    }
+
+    this._totalAppended += chunkLen
+
+    if (chunkLen >= this._capacity) {
+      // Chunk completely replaced buffer contents — head is where we started writing
+      this._head = writePos
+      this._length = this._capacity
+      this._trimPyramid(chunkLen)
+    } else {
+      const newTotal = this._length + chunkLen
+      const overflow = newTotal > this._capacity ? newTotal - this._capacity : 0
+      if (overflow > 0) {
+        this._head = (this._head + overflow) % this._capacity
+        this._length = this._capacity
+        this._trimPyramid(overflow)
+      } else {
+        this._length += chunkLen
+      }
+    }
+  }
+
+  /**
+   * Feed a single sample value into the decimation pyramid accumulators.
+   * @param {number} value - 0 or 1
+   */
+  _feedSample(value) {
+    const acc = this._accumulators[0]
+    if (value) acc.hasHigh = true
+    else acc.hasLow = true
+    acc.count++
+
+    if (acc.count === DECIMATION_FACTOR) {
+      const packed = (acc.hasLow ? HAS_LOW : 0) | (acc.hasHigh ? HAS_HIGH : 0)
+      this._writePyramidEntry(0, packed)
+      acc.hasLow = false
+      acc.hasHigh = false
+      acc.count = 0
+    }
+  }
+
+  /**
+   * Write an entry to a pyramid level and cascade upward.
+   * @param {number} level
+   * @param {number} packed - bit flags (HAS_LOW | HAS_HIGH)
+   */
+  _writePyramidEntry(level, packed) {
+    const pyr = this._pyramid[level]
+    const writePos = (pyr.head + pyr.length) % pyr.capacity
+    pyr.data[writePos] = packed
+
+    if (pyr.length < pyr.capacity) {
+      pyr.length++
+    } else {
+      // Ring wrap: advance head
+      pyr.head = (pyr.head + 1) % pyr.capacity
+    }
+
+    // Cascade to next level
+    if (level + 1 < PYRAMID_LEVELS) {
+      const nextAcc = this._accumulators[level + 1]
+      if (packed & HAS_LOW) nextAcc.hasLow = true
+      if (packed & HAS_HIGH) nextAcc.hasHigh = true
+      nextAcc.count++
+
+      if (nextAcc.count === DECIMATION_FACTOR) {
+        const nextPacked = (nextAcc.hasLow ? HAS_LOW : 0) | (nextAcc.hasHigh ? HAS_HIGH : 0)
+        this._writePyramidEntry(level + 1, nextPacked)
+        nextAcc.hasLow = false
+        nextAcc.hasHigh = false
+        nextAcc.count = 0
+      }
+    }
+  }
+
+  /**
+   * Trim pyramid heads after the raw ring buffer discards samples from the front.
+   * @param {number} rawTrimmed - Number of raw samples trimmed
+   */
+  _trimPyramid() {
+    for (let level = 0; level < PYRAMID_LEVELS; level++) {
+      const factor = LEVEL_FACTORS[level]
+      const pyr = this._pyramid[level]
+
+      // The pyramid should have entries covering the raw data range.
+      // After trimming, we know how many complete groups the raw data spans.
+      // The pyramid length should not exceed ceil(rawLength / factor).
+      const maxEntries = Math.ceil(this._length / factor)
+      if (pyr.length > maxEntries) {
+        const excess = pyr.length - maxEntries
+        pyr.head = (pyr.head + excess) % pyr.capacity
+        pyr.length = maxEntries
+      }
+    }
+  }
+
+  /**
+   * Materialize a contiguous Uint8Array copy of stored samples.
+   * Handles ring buffer wrap-around.
+   *
+   * @param {number} [start=0] - Logical start index
+   * @param {number} [count] - Number of samples (defaults to all from start)
+   * @returns {Uint8Array}
+   */
+  toUint8Array(start = 0, count = undefined) {
+    const len = count !== undefined ? count : this._length - start
+    if (len <= 0) return new Uint8Array(0)
+
+    const result = new Uint8Array(len)
+    const physStart = (this._head + start) % this._capacity
+
+    const spaceToEnd = this._capacity - physStart
+    if (len <= spaceToEnd) {
+      result.set(this._data.subarray(physStart, physStart + len))
+    } else {
+      result.set(this._data.subarray(physStart, this._capacity))
+      result.set(this._data.subarray(0, len - spaceToEnd), spaceToEnd)
+    }
+
+    return result
+  }
+
+  /**
+   * Produce a per-pixel-column summary using the decimation pyramid.
+   * Returns the same 0/1/2 format as the renderer's computeColumnSummary().
+   *
+   * @param {number} firstSample - Logical index of first visible sample
+   * @param {number} samplesPerPixel - How many samples each pixel column spans
+   * @param {number} pixelCount - Number of pixel columns to produce
+   * @returns {Uint8Array} summary (0=low, 1=high, 2=mixed)
+   */
+  getColumnSummary(firstSample, samplesPerPixel, pixelCount) {
+    // Pick the coarsest pyramid level where factor <= samplesPerPixel
+    let level = -1
+    for (let i = PYRAMID_LEVELS - 1; i >= 0; i--) {
+      if (samplesPerPixel >= LEVEL_FACTORS[i]) {
+        level = i
+        break
+      }
+    }
+
+    const summary = new Uint8Array(pixelCount)
+
+    if (level === -1) {
+      // samplesPerPixel < 10: scan raw samples directly
+      this._columnSummaryFromRaw(summary, firstSample, samplesPerPixel, pixelCount)
+    } else {
+      this._columnSummaryFromPyramid(summary, firstSample, samplesPerPixel, pixelCount, level)
+    }
+
+    return summary
+  }
+
+  /**
+   * Compute column summary by scanning raw samples.
+   * Used when samplesPerPixel < 10 (already fast per pixel).
+   */
+  _columnSummaryFromRaw(summary, firstSample, samplesPerPixel, pixelCount) {
+    for (let px = 0; px < pixelCount; px++) {
+      const sStart = Math.floor(firstSample + px * samplesPerPixel)
+      const sEnd = Math.min(
+        Math.ceil(firstSample + (px + 1) * samplesPerPixel),
+        this._length,
+      )
+
+      if (sStart >= this._length) {
+        summary[px] = 0
+        continue
+      }
+
+      let hasHigh = false
+      let hasLow = false
+      for (let s = sStart; s < sEnd; s++) {
+        if (this.get(s)) hasHigh = true
+        else hasLow = true
+        if (hasHigh && hasLow) break
+      }
+
+      summary[px] = hasHigh && hasLow ? 2 : hasHigh ? 1 : 0
+    }
+  }
+
+  /**
+   * Compute column summary by reading pre-computed pyramid entries.
+   * Each pyramid entry already has hasLow/hasHigh flags, so we just OR them.
+   */
+  _columnSummaryFromPyramid(summary, firstSample, samplesPerPixel, pixelCount, level) {
+    const factor = LEVEL_FACTORS[level]
+    const pyr = this._pyramid[level]
+
+    for (let px = 0; px < pixelCount; px++) {
+      const rawStart = firstSample + px * samplesPerPixel
+      const rawEnd = firstSample + (px + 1) * samplesPerPixel
+      const pStart = Math.floor(rawStart / factor)
+      const pEnd = Math.ceil(rawEnd / factor)
+
+      let combined = 0
+      const maxP = Math.min(pEnd, pyr.length)
+      for (let p = pStart; p < maxP; p++) {
+        combined |= pyr.data[(pyr.head + p) % pyr.capacity]
+        if (combined === 3) break
+      }
+
+      // Translate bit flags to 0/1/2 format
+      // 0 (or no entries) → 0 (low), 1 (hasLow only) → 0, 2 (hasHigh only) → 1, 3 (both) → 2
+      summary[px] = combined === 3 ? 2 : combined & HAS_HIGH ? 1 : 0
+    }
+  }
+
+  /**
+   * Read a pyramid entry by logical index at a given level.
+   * Exposed for testing.
+   *
+   * @param {number} level - Pyramid level (0-3)
+   * @param {number} index - Logical index
+   * @returns {number} Packed flags (HAS_LOW | HAS_HIGH)
+   */
+  getPyramidEntry(level, index) {
+    const pyr = this._pyramid[level]
+    return pyr.data[(pyr.head + index) % pyr.capacity]
+  }
+
+  /**
+   * Get the number of entries at a pyramid level.
+   * @param {number} level
+   * @returns {number}
+   */
+  getPyramidLength(level) {
+    return this._pyramid[level].length
+  }
+
+  /** Reset all state. */
+  clear() {
+    this._head = 0
+    this._length = 0
+    this._totalAppended = 0
+
+    for (let level = 0; level < PYRAMID_LEVELS; level++) {
+      const pyr = this._pyramid[level]
+      pyr.head = 0
+      pyr.length = 0
+      this._accumulators[level] = { hasLow: false, hasHigh: false, count: 0 }
+    }
+  }
+}

--- a/Software/Web/src/core/sample-buffer.test.js
+++ b/Software/Web/src/core/sample-buffer.test.js
@@ -1,0 +1,359 @@
+import { describe, it, expect } from 'vitest'
+import { SampleBuffer } from './sample-buffer.js'
+import { computeColumnSummary } from './renderer/waveform-renderer.js'
+
+describe('SampleBuffer', () => {
+  describe('ring buffer basics', () => {
+    it('starts empty', () => {
+      const buf = new SampleBuffer(100)
+      expect(buf.length).toBe(0)
+      expect(buf.capacity).toBe(100)
+    })
+
+    it('appends and reads samples', () => {
+      const buf = new SampleBuffer(100)
+      buf.append(new Uint8Array([0, 1, 1, 0, 1]))
+      expect(buf.length).toBe(5)
+      expect(buf.get(0)).toBe(0)
+      expect(buf.get(1)).toBe(1)
+      expect(buf.get(2)).toBe(1)
+      expect(buf.get(3)).toBe(0)
+      expect(buf.get(4)).toBe(1)
+    })
+
+    it('appends multiple chunks', () => {
+      const buf = new SampleBuffer(100)
+      buf.append(new Uint8Array([1, 0]))
+      buf.append(new Uint8Array([0, 1, 1]))
+      expect(buf.length).toBe(5)
+      expect(buf.get(0)).toBe(1)
+      expect(buf.get(4)).toBe(1)
+    })
+
+    it('wraps around when capacity exceeded', () => {
+      const buf = new SampleBuffer(5)
+      buf.append(new Uint8Array([1, 0, 1, 0, 1])) // full
+      buf.append(new Uint8Array([0, 0])) // overwrites first 2
+
+      expect(buf.length).toBe(5)
+      // oldest remaining: [1, 0, 1, 0, 0]
+      expect(buf.get(0)).toBe(1)
+      expect(buf.get(1)).toBe(0)
+      expect(buf.get(2)).toBe(1)
+      expect(buf.get(3)).toBe(0)
+      expect(buf.get(4)).toBe(0)
+    })
+
+    it('wraps around with large overflow', () => {
+      const buf = new SampleBuffer(4)
+      buf.append(new Uint8Array([1, 0, 1, 0, 1, 1, 0, 0, 1, 0]))
+      // capacity 4, appended 10 → keeps last 4: [0, 1, 0]... wait
+      // last 4 samples: indices 6,7,8,9 → [0, 0, 1, 0]
+      expect(buf.length).toBe(4)
+      expect(buf.get(0)).toBe(0)
+      expect(buf.get(1)).toBe(0)
+      expect(buf.get(2)).toBe(1)
+      expect(buf.get(3)).toBe(0)
+    })
+
+    it('handles empty chunk append', () => {
+      const buf = new SampleBuffer(10)
+      buf.append(new Uint8Array([1, 0]))
+      buf.append(new Uint8Array([]))
+      expect(buf.length).toBe(2)
+    })
+  })
+
+  describe('flat mode', () => {
+    it('throws on overflow in flat mode', () => {
+      const buf = new SampleBuffer(3, { ring: false })
+      buf.append(new Uint8Array([1, 0, 1]))
+      expect(() => buf.append(new Uint8Array([0]))).toThrow('flat buffer overflow')
+    })
+
+    it('works within capacity', () => {
+      const buf = new SampleBuffer(5, { ring: false })
+      buf.append(new Uint8Array([1, 0, 1]))
+      expect(buf.length).toBe(3)
+      expect(buf.get(0)).toBe(1)
+      expect(buf.get(2)).toBe(1)
+    })
+  })
+
+  describe('fromUint8Array', () => {
+    it('creates buffer with correct data', () => {
+      const data = new Uint8Array([0, 1, 1, 0, 0, 1, 0, 1, 1, 0])
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.length).toBe(10)
+      for (let i = 0; i < 10; i++) {
+        expect(buf.get(i)).toBe(data[i])
+      }
+    })
+
+    it('builds pyramid for data with complete groups', () => {
+      // 10 samples → 1 pyramid entry at level 0
+      const data = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(2) // hasHigh only
+    })
+  })
+
+  describe('toUint8Array', () => {
+    it('returns all data', () => {
+      const buf = new SampleBuffer(10)
+      buf.append(new Uint8Array([0, 1, 1, 0, 1]))
+      const arr = buf.toUint8Array()
+      expect(arr).toEqual(new Uint8Array([0, 1, 1, 0, 1]))
+    })
+
+    it('handles wrap-around', () => {
+      const buf = new SampleBuffer(4)
+      buf.append(new Uint8Array([1, 0, 1, 0])) // full
+      buf.append(new Uint8Array([1, 1])) // wraps
+      const arr = buf.toUint8Array()
+      expect(arr).toEqual(new Uint8Array([1, 0, 1, 1]))
+    })
+
+    it('returns slice with start and count', () => {
+      const buf = new SampleBuffer(10)
+      buf.append(new Uint8Array([0, 1, 1, 0, 1]))
+      const arr = buf.toUint8Array(1, 3)
+      expect(arr).toEqual(new Uint8Array([1, 1, 0]))
+    })
+
+    it('returns empty array for zero count', () => {
+      const buf = new SampleBuffer(10)
+      buf.append(new Uint8Array([0, 1]))
+      const arr = buf.toUint8Array(0, 0)
+      expect(arr).toEqual(new Uint8Array([]))
+    })
+  })
+
+  describe('decimation pyramid', () => {
+    it('produces correct level-0 entry for all-low group', () => {
+      const data = new Uint8Array(10).fill(0)
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(1) // hasLow only
+    })
+
+    it('produces correct level-0 entry for all-high group', () => {
+      const data = new Uint8Array(10).fill(1)
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(2) // hasHigh only
+    })
+
+    it('produces correct level-0 entry for mixed group', () => {
+      const data = new Uint8Array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(3) // both
+    })
+
+    it('builds multiple level-0 entries', () => {
+      // 30 samples → 3 level-0 entries
+      const data = new Uint8Array(30)
+      data.fill(0, 0, 10) // group 0: all low
+      data.fill(1, 10, 20) // group 1: all high
+      data.fill(0, 20, 25) // group 2: mixed
+      data.fill(1, 25, 30)
+
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(3)
+      expect(buf.getPyramidEntry(0, 0)).toBe(1) // hasLow
+      expect(buf.getPyramidEntry(0, 1)).toBe(2) // hasHigh
+      expect(buf.getPyramidEntry(0, 2)).toBe(3) // mixed
+    })
+
+    it('does not create level-0 entry for incomplete group', () => {
+      // 15 samples → 1 complete group, 5 leftover
+      const data = new Uint8Array(15).fill(1)
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(1)
+    })
+
+    it('builds level-1 entry from 100 samples', () => {
+      // 100 samples → 10 level-0 entries → 1 level-1 entry
+      const data = new Uint8Array(100).fill(1)
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(10)
+      expect(buf.getPyramidLength(1)).toBe(1)
+      expect(buf.getPyramidEntry(1, 0)).toBe(2) // hasHigh only
+    })
+
+    it('builds level-2 entry from 1000 samples', () => {
+      const data = new Uint8Array(1000).fill(0)
+      const buf = SampleBuffer.fromUint8Array(data)
+      expect(buf.getPyramidLength(0)).toBe(100)
+      expect(buf.getPyramidLength(1)).toBe(10)
+      expect(buf.getPyramidLength(2)).toBe(1)
+      expect(buf.getPyramidEntry(2, 0)).toBe(1) // hasLow only
+    })
+
+    it('cascades mixed flags through levels', () => {
+      // 100 samples: first 50 low, last 50 high
+      const data = new Uint8Array(100)
+      data.fill(0, 0, 50)
+      data.fill(1, 50, 100)
+      const buf = SampleBuffer.fromUint8Array(data)
+
+      // Level 0: groups 0-4 are all-low, groups 5-9 are all-high
+      expect(buf.getPyramidEntry(0, 0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 4)).toBe(1)
+      expect(buf.getPyramidEntry(0, 5)).toBe(2)
+      expect(buf.getPyramidEntry(0, 9)).toBe(2)
+
+      // Level 1: single entry should be mixed (has both low and high groups)
+      expect(buf.getPyramidLength(1)).toBe(1)
+      expect(buf.getPyramidEntry(1, 0)).toBe(3) // both flags
+    })
+
+    it('handles accumulator continuity across multiple appends', () => {
+      const buf = new SampleBuffer(100)
+      // Append 7 samples, then 3 more to complete a group of 10
+      buf.append(new Uint8Array([1, 1, 1, 1, 1, 1, 1]))
+      expect(buf.getPyramidLength(0)).toBe(0) // not enough yet
+
+      buf.append(new Uint8Array([1, 1, 1]))
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(2) // all high
+    })
+
+    it('handles accumulator continuity with mixed values across boundary', () => {
+      const buf = new SampleBuffer(100)
+      buf.append(new Uint8Array([0, 0, 0, 0, 0])) // 5 lows
+      buf.append(new Uint8Array([1, 1, 1, 1, 1])) // 5 highs → completes group
+      expect(buf.getPyramidLength(0)).toBe(1)
+      expect(buf.getPyramidEntry(0, 0)).toBe(3) // mixed
+    })
+  })
+
+  describe('pyramid with ring buffer trim', () => {
+    it('trims pyramid entries when raw data wraps', () => {
+      const buf = new SampleBuffer(20)
+
+      // Fill with 20 samples (2 level-0 entries)
+      buf.append(new Uint8Array(20).fill(0))
+      expect(buf.getPyramidLength(0)).toBe(2)
+
+      // Append 10 more → oldest 10 trimmed → should have 2 entries still
+      buf.append(new Uint8Array(10).fill(1))
+      expect(buf.length).toBe(20)
+      expect(buf.getPyramidLength(0)).toBe(2)
+    })
+
+    it('pyramid reflects data after trim', () => {
+      const buf = new SampleBuffer(20)
+
+      // Fill with 20 lows
+      buf.append(new Uint8Array(20).fill(0))
+      expect(buf.getPyramidEntry(0, 0)).toBe(1) // hasLow
+      expect(buf.getPyramidEntry(0, 1)).toBe(1)
+
+      // Append 10 highs → oldest 10 (lows) trimmed
+      buf.append(new Uint8Array(10).fill(1))
+      // Now have: 10 lows + 10 highs
+      // Entry 0 should be low (the remaining original lows), entry 1 should be high
+      // After trim, pyramid[0] should have entries [low, high]
+      expect(buf.getPyramidLength(0)).toBe(2)
+    })
+  })
+
+  describe('getColumnSummary', () => {
+    it('returns all-low for zero data', () => {
+      const buf = SampleBuffer.fromUint8Array(new Uint8Array(100).fill(0))
+      const summary = buf.getColumnSummary(0, 10, 10)
+      for (let i = 0; i < 10; i++) {
+        expect(summary[i]).toBe(0) // low
+      }
+    })
+
+    it('returns all-high for one data', () => {
+      const buf = SampleBuffer.fromUint8Array(new Uint8Array(100).fill(1))
+      const summary = buf.getColumnSummary(0, 10, 10)
+      for (let i = 0; i < 10; i++) {
+        expect(summary[i]).toBe(1) // high
+      }
+    })
+
+    it('returns mixed for alternating data', () => {
+      const data = new Uint8Array(100)
+      for (let i = 0; i < 100; i++) data[i] = i % 2
+      const buf = SampleBuffer.fromUint8Array(data)
+      const summary = buf.getColumnSummary(0, 10, 10)
+      for (let i = 0; i < 10; i++) {
+        expect(summary[i]).toBe(2) // mixed
+      }
+    })
+
+    it('matches computeColumnSummary for small samplesPerPixel', () => {
+      // samplesPerPixel < 10 → uses raw scan path
+      const data = new Uint8Array(50)
+      for (let i = 0; i < 50; i++) data[i] = i < 25 ? 0 : 1
+
+      const buf = SampleBuffer.fromUint8Array(data)
+
+      const spp = 5
+      const pixelCount = 10
+      const bufSummary = buf.getColumnSummary(0, spp, pixelCount)
+      const rawSummary = computeColumnSummary(data, 0, spp, pixelCount)
+
+      expect(bufSummary).toEqual(rawSummary)
+    })
+
+    it('produces correct results using pyramid for large samplesPerPixel', () => {
+      // 1000 samples, 100 spp, 10 pixels → uses level-1 (factor=100)
+      const data = new Uint8Array(1000)
+      data.fill(0, 0, 500) // first half low
+      data.fill(1, 500, 1000) // second half high
+
+      const buf = SampleBuffer.fromUint8Array(data)
+      const summary = buf.getColumnSummary(0, 100, 10)
+
+      // Pixels 0-4: all low, pixels 5-9: all high
+      for (let i = 0; i < 5; i++) expect(summary[i]).toBe(0)
+      for (let i = 5; i < 10; i++) expect(summary[i]).toBe(1)
+    })
+
+    it('handles partial coverage at end', () => {
+      const buf = SampleBuffer.fromUint8Array(new Uint8Array(50).fill(1))
+      // Request 10 pixels at 10 spp, but only 50 samples → last 5 pixels have no data
+      const summary = buf.getColumnSummary(0, 10, 10)
+      for (let i = 0; i < 5; i++) expect(summary[i]).toBe(1) // high
+      for (let i = 5; i < 10; i++) expect(summary[i]).toBe(0) // no data
+    })
+
+    it('uses pyramid at large scale', () => {
+      // 10000 samples → uses level-2 (factor=1000) at 1000 spp
+      const data = new Uint8Array(10000).fill(1)
+      const buf = SampleBuffer.fromUint8Array(data)
+      const summary = buf.getColumnSummary(0, 1000, 10)
+      for (let i = 0; i < 10; i++) expect(summary[i]).toBe(1)
+    })
+  })
+
+  describe('clear', () => {
+    it('resets all state', () => {
+      const buf = new SampleBuffer(100)
+      buf.append(new Uint8Array(50).fill(1))
+      expect(buf.length).toBe(50)
+      expect(buf.getPyramidLength(0)).toBe(5)
+
+      buf.clear()
+      expect(buf.length).toBe(0)
+      expect(buf.getPyramidLength(0)).toBe(0)
+    })
+
+    it('allows reuse after clear', () => {
+      const buf = new SampleBuffer(100)
+      buf.append(new Uint8Array(50).fill(1))
+      buf.clear()
+      buf.append(new Uint8Array([0, 1, 0]))
+      expect(buf.length).toBe(3)
+      expect(buf.get(0)).toBe(0)
+      expect(buf.get(1)).toBe(1)
+    })
+  })
+})

--- a/Software/Web/src/stores/capture.test.js
+++ b/Software/Web/src/stores/capture.test.js
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { useCaptureStore } from './capture.js'
 import { useChannelConfigStore } from './channel-config.js'
 import { useDeviceStore } from './device.js'
+import { SampleBuffer } from '../core/sample-buffer.js'
 
 function createMockStorage() {
   const store = {}
@@ -68,9 +69,9 @@ vi.mock('../core/driver/analyzer.js', () => {
       return session.captureChannels.length > 0 && session.frequency > 0
     }
     async startCapture(session, onComplete) {
-      // Simulate successful capture with sample data
+      // Simulate successful capture with sample data (matches real driver returning SampleBuffer)
       session.captureChannels.forEach((ch) => {
-        ch.samples = new Uint8Array([1, 0, 1, 0])
+        ch.samples = SampleBuffer.fromUint8Array(new Uint8Array([1, 0, 1, 0]))
       })
       onComplete({ success: true, session })
     }
@@ -197,7 +198,7 @@ describe('useCaptureStore', () => {
       expect(capture.channels).toHaveLength(2)
       expect(capture.channels[0].samples).toBeNull() // config channels have no samples
       expect(capture.capturedChannels).toHaveLength(2)
-      expect(capture.capturedChannels[0].samples).toEqual(new Uint8Array([1, 0, 1]))
+      expect(capture.capturedChannels[0].samples.toUint8Array()).toEqual(new Uint8Array([1, 0, 1]))
       expect(capture.regions).toHaveLength(1)
       expect(capture.regions[0].regionName).toBe('R1')
       expect(capture.captureError).toBeNull()
@@ -211,7 +212,7 @@ describe('useCaptureStore', () => {
 
       expect(capture.capturedChannels).toHaveLength(2)
       expect(capture.capturedChannels[0].channelName).toBe('CLK')
-      expect(capture.capturedChannels[0].samples).toEqual(new Uint8Array([1, 0, 1]))
+      expect(capture.capturedChannels[0].samples.toUint8Array()).toEqual(new Uint8Array([1, 0, 1]))
       expect(capture.channels).toHaveLength(2)
       expect(capture.channels[0].samples).toBeNull()
       expect(capture.preTriggerSamples).toBe(0)
@@ -331,7 +332,7 @@ describe('useCaptureStore', () => {
       await capture.startCapture()
 
       expect(capture.capturedChannels).toHaveLength(2)
-      expect(capture.capturedChannels[0].samples).toEqual(new Uint8Array([1, 0, 1, 0]))
+      expect(capture.capturedChannels[0].samples.toUint8Array()).toEqual(new Uint8Array([1, 0, 1, 0]))
       expect(capture.captureError).toBeNull()
       expect(device.capturing).toBe(false)
     })
@@ -379,7 +380,9 @@ describe('useCaptureStore', () => {
       // The capturedChannels array itself may be proxied by Pinia
       // but the Uint8Array samples inside should not be deeply reactive
       const samples = capture.capturedChannels[0].samples
-      expect(samples).toBeInstanceOf(Uint8Array)
+      // SampleBuffer should not be deeply proxied by Pinia's reactivity
+      expect(samples).toBeDefined()
+      expect(typeof samples.get).toBe('function')
     })
   })
 })

--- a/Software/Web/src/stores/cursor.js
+++ b/Software/Web/src/stores/cursor.js
@@ -1,0 +1,31 @@
+import { ref } from 'vue'
+import { defineStore, acceptHMRUpdate } from 'pinia'
+
+export const useCursorStore = defineStore('cursor', () => {
+  /** Sample index under the cursor, or null if cursor is off-canvas. */
+  const cursorSample = ref(null)
+
+  /** CSS pixel x position (snapped or raw), or null if cursor is off-canvas. */
+  const cursorX = ref(null)
+
+  function setCursor(sample, x) {
+    cursorSample.value = sample
+    cursorX.value = x
+  }
+
+  function clearCursor() {
+    cursorSample.value = null
+    cursorX.value = null
+  }
+
+  return {
+    cursorSample,
+    cursorX,
+    setCursor,
+    clearCursor,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useCursorStore, import.meta.hot))
+}

--- a/Software/Web/src/stores/cursor.js
+++ b/Software/Web/src/stores/cursor.js
@@ -8,19 +8,25 @@ export const useCursorStore = defineStore('cursor', () => {
   /** CSS pixel x position (snapped or raw), or null if cursor is off-canvas. */
   const cursorX = ref(null)
 
-  function setCursor(sample, x) {
+  /** Raw mouse CSS pixel x — preserved across viewport changes for recalculation. */
+  const rawX = ref(null)
+
+  function setCursor(sample, x, raw) {
     cursorSample.value = sample
     cursorX.value = x
+    rawX.value = raw
   }
 
   function clearCursor() {
     cursorSample.value = null
     cursorX.value = null
+    rawX.value = null
   }
 
   return {
     cursorSample,
     cursorX,
+    rawX,
     setCursor,
     clearCursor,
   }

--- a/Software/Web/src/stores/cursor.test.js
+++ b/Software/Web/src/stores/cursor.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCursorStore } from './cursor.js'
+
+describe('useCursorStore', () => {
+  let store
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useCursorStore()
+  })
+
+  it('starts with null cursor', () => {
+    expect(store.cursorSample).toBeNull()
+    expect(store.cursorX).toBeNull()
+  })
+
+  it('setCursor sets sample and x', () => {
+    store.setCursor(42, 300.5)
+    expect(store.cursorSample).toBe(42)
+    expect(store.cursorX).toBe(300.5)
+  })
+
+  it('clearCursor resets to null', () => {
+    store.setCursor(42, 300.5)
+    store.clearCursor()
+    expect(store.cursorSample).toBeNull()
+    expect(store.cursorX).toBeNull()
+  })
+
+  it('setCursor overwrites previous values', () => {
+    store.setCursor(10, 100)
+    store.setCursor(20, 200)
+    expect(store.cursorSample).toBe(20)
+    expect(store.cursorX).toBe(200)
+  })
+})

--- a/Software/Web/src/stores/cursor.test.js
+++ b/Software/Web/src/stores/cursor.test.js
@@ -13,25 +13,29 @@ describe('useCursorStore', () => {
   it('starts with null cursor', () => {
     expect(store.cursorSample).toBeNull()
     expect(store.cursorX).toBeNull()
+    expect(store.rawX).toBeNull()
   })
 
-  it('setCursor sets sample and x', () => {
-    store.setCursor(42, 300.5)
+  it('setCursor sets sample, x, and rawX', () => {
+    store.setCursor(42, 300.5, 305)
     expect(store.cursorSample).toBe(42)
     expect(store.cursorX).toBe(300.5)
+    expect(store.rawX).toBe(305)
   })
 
-  it('clearCursor resets to null', () => {
-    store.setCursor(42, 300.5)
+  it('clearCursor resets all to null', () => {
+    store.setCursor(42, 300.5, 305)
     store.clearCursor()
     expect(store.cursorSample).toBeNull()
     expect(store.cursorX).toBeNull()
+    expect(store.rawX).toBeNull()
   })
 
   it('setCursor overwrites previous values', () => {
-    store.setCursor(10, 100)
-    store.setCursor(20, 200)
+    store.setCursor(10, 100, 105)
+    store.setCursor(20, 200, 210)
     expect(store.cursorSample).toBe(20)
     expect(store.cursorX).toBe(200)
+    expect(store.rawX).toBe(210)
   })
 })

--- a/Software/Web/src/stores/stream.js
+++ b/Software/Web/src/stores/stream.js
@@ -4,6 +4,7 @@ import { useLocalStorage } from '@vueuse/core'
 import { useDeviceStore } from './device.js'
 import { useViewportStore } from './viewport.js'
 import { createChannel } from '../core/driver/types.js'
+import { SampleBuffer } from '../core/sample-buffer.js'
 
 export const useStreamStore = defineStore('stream', () => {
   // Config (persisted)
@@ -59,6 +60,9 @@ export const useStreamStore = defineStore('stream', () => {
   let absoluteSamplesReceived = 0
   let samplesSinceLastReport = 0
   const FLUSH_INTERVAL_MS = 16 // ~60fps
+
+  // Pre-allocated ring buffers — one per channel (module-level, non-reactive)
+  let buffers = []
 
   /**
    * Unpacks a transposed bitstream (chunkSamples/8 bytes) into per-sample 0/1 Uint8Array.
@@ -138,38 +142,24 @@ export const useStreamStore = defineStore('stream', () => {
     const chunks = pendingChunks
     pendingChunks = []
 
-    const current = streamChannels.value
-    if (current.length === 0) return
+    if (buffers.length === 0) return
 
-    const max = maxDisplaySamples.value
-
-    // Calculate total new samples
-    let totalNew = 0
+    // Append each chunk's data directly into the pre-allocated ring buffers
     for (const chunk of chunks) {
-      totalNew += chunk.chunkSamples
+      for (let chIdx = 0; chIdx < buffers.length; chIdx++) {
+        buffers[chIdx].append(chunk.unpacked[chIdx])
+      }
     }
 
-    const updated = current.map((ch, chIdx) => {
-      const existing = ch.samples
-      const existingLen = existing ? existing.length : 0
-
-      // Allocate combined buffer
-      const combined = new Uint8Array(existingLen + totalNew)
-      if (existing) combined.set(existing)
-
-      let offset = existingLen
-      for (const chunk of chunks) {
-        combined.set(chunk.unpacked[chIdx], offset)
-        offset += chunk.chunkSamples
-      }
-
-      // Trim to maxDisplaySamples from the end
-      const trimmed = combined.length > max ? combined.slice(combined.length - max) : combined
-      return { ...ch, samples: trimmed }
-    })
+    // Update reactive state — replace channel objects to trigger Vue reactivity
+    const current = streamChannels.value
+    const updated = current.map((ch, chIdx) => ({
+      ...ch,
+      samples: buffers[chIdx],
+    }))
 
     streamChannels.value = updated
-    sampleCount.value = updated[0]?.samples?.length ?? 0
+    sampleCount.value = buffers[0]?.length ?? 0
 
     // Update display offset for loss region coordinate mapping and prune old regions
     displayOffset.value = absoluteSamplesReceived - sampleCount.value
@@ -229,11 +219,16 @@ export const useStreamStore = defineStore('stream', () => {
 
     const channelNumbers = channelsToStream.map((ch) => ch.channelNumber)
     const freq = streamFrequency.value
+    const max = maxDisplaySamples.value
+
+    // Pre-allocate ring buffers for each channel
+    buffers = channelsToStream.map(() => new SampleBuffer(max))
 
     // Create channel objects with empty sample buffers
-    streamChannels.value = channelsToStream.map((ch) =>
-      createChannel(ch.channelNumber, ch.channelName, ch.channelColor),
-    )
+    streamChannels.value = channelsToStream.map((ch, i) => ({
+      ...createChannel(ch.channelNumber, ch.channelName, ch.channelColor),
+      samples: buffers[i],
+    }))
     sampleCount.value = 0
     following.value = true
     pendingChunks = []
@@ -264,6 +259,7 @@ export const useStreamStore = defineStore('stream', () => {
     } else {
       streamError.value = result.error || 'Failed to start stream'
       streamChannels.value = []
+      buffers = []
     }
   }
 
@@ -297,6 +293,7 @@ export const useStreamStore = defineStore('stream', () => {
     absoluteSamplesReceived = 0
     samplesSinceLastReport = 0
     streamStartedAt = 0
+    buffers = []
     const device = useDeviceStore()
     device.streaming = false
   }

--- a/Software/Web/src/stores/viewport.js
+++ b/Software/Web/src/stores/viewport.js
@@ -38,6 +38,7 @@ function findZoomIndex(value) {
 export const useViewportStore = defineStore('viewport', () => {
   const firstSample = ref(0)
   const visibleSamples = ref(100)
+  const canvasWidth = ref(0)
 
   function getEffectiveTotalSamples() {
     const stream = useStreamStore()
@@ -133,6 +134,10 @@ export const useViewportStore = defineStore('viewport', () => {
     visibleSamples.value = total
   }
 
+  function setCanvasWidth(w) {
+    canvasWidth.value = w
+  }
+
   async function reset() {
     firstSample.value = 0
     visibleSamples.value = 100
@@ -142,6 +147,7 @@ export const useViewportStore = defineStore('viewport', () => {
     firstSample,
     visibleSamples,
     lastVisibleSample,
+    canvasWidth,
     canZoomIn,
     canZoomOut,
     totalSamples,
@@ -153,6 +159,7 @@ export const useViewportStore = defineStore('viewport', () => {
     scrollLeft,
     scrollRight,
     fitAll,
+    setCanvasWidth,
     reset,
   }
 })

--- a/Software/Web/src/stores/viewport.js
+++ b/Software/Web/src/stores/viewport.js
@@ -71,27 +71,35 @@ export const useViewportStore = defineStore('viewport', () => {
     visibleSamples.value = v
   }
 
-  async function zoomIn(center = null) {
+  /**
+   * Zoom in one level.
+   * @param {number|null} anchor - sample index to keep in place (null = viewport center)
+   * @param {number} fraction - screen fraction of anchor (0=left, 1=right, 0.5=center)
+   */
+  async function zoomIn(anchor = null, fraction = 0.5) {
     if (!canZoomIn.value) return
     const idx = findZoomIndex(visibleSamples.value)
-    // Step down one level, but only if we're actually at or above that level
     const newIdx = ZOOM_LEVELS[idx] >= visibleSamples.value ? Math.max(0, idx - 1) : idx
     const newVisible = ZOOM_LEVELS[newIdx]
-    const mid = center ?? firstSample.value + Math.floor(visibleSamples.value / 2)
-    const newFirst = mid - Math.floor(newVisible / 2)
+    const mid = anchor ?? firstSample.value + Math.floor(visibleSamples.value / 2)
+    const newFirst = Math.round(mid - fraction * newVisible)
     const { first: f, visible: v } = clamp(newFirst, newVisible)
     firstSample.value = f
     visibleSamples.value = v
   }
 
-  async function zoomOut(center = null) {
+  /**
+   * Zoom out one level.
+   * @param {number|null} anchor - sample index to keep in place (null = viewport center)
+   * @param {number} fraction - screen fraction of anchor (0=left, 1=right, 0.5=center)
+   */
+  async function zoomOut(anchor = null, fraction = 0.5) {
     if (!canZoomOut.value) return
     const idx = findZoomIndex(visibleSamples.value)
-    // Step up one level
     const newIdx = Math.min(ZOOM_LEVELS.length - 1, idx + 1)
     const newVisible = ZOOM_LEVELS[newIdx]
-    const mid = center ?? firstSample.value + Math.floor(visibleSamples.value / 2)
-    const newFirst = mid - Math.floor(newVisible / 2)
+    const mid = anchor ?? firstSample.value + Math.floor(visibleSamples.value / 2)
+    const newFirst = Math.round(mid - fraction * newVisible)
     const { first: f, visible: v } = clamp(newFirst, newVisible)
     firstSample.value = f
     visibleSamples.value = v

--- a/Software/Web/src/stores/viewport.js
+++ b/Software/Web/src/stores/viewport.js
@@ -4,8 +4,36 @@ import { useCaptureStore } from './capture.js'
 import { useStreamStore } from './stream.js'
 
 const MIN_VISIBLE_SAMPLES = 10
-const ZOOM_FACTOR = 0.5
 const SCROLL_FACTOR = 0.1
+
+/**
+ * Pregenerated table of zoom levels (visible sample counts).
+ * Each step is ~1.5x the previous, producing clean integer values.
+ * Covers from MIN_VISIBLE_SAMPLES up to 10 billion — far beyond any real capture.
+ */
+export const ZOOM_LEVELS = (() => {
+  const levels = [MIN_VISIBLE_SAMPLES]
+  while (levels[levels.length - 1] < 1e10) {
+    const next = Math.round(levels[levels.length - 1] * 1.5)
+    levels.push(next)
+  }
+  return levels
+})()
+
+/**
+ * Find the index of the largest zoom level <= value.
+ * Returns 0 if value is at or below the minimum.
+ */
+function findZoomIndex(value) {
+  let lo = 0
+  let hi = ZOOM_LEVELS.length - 1
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1
+    if (ZOOM_LEVELS[mid] <= value) lo = mid
+    else hi = mid - 1
+  }
+  return lo
+}
 
 export const useViewportStore = defineStore('viewport', () => {
   const firstSample = ref(0)
@@ -45,7 +73,10 @@ export const useViewportStore = defineStore('viewport', () => {
 
   async function zoomIn(center = null) {
     if (!canZoomIn.value) return
-    const newVisible = Math.max(MIN_VISIBLE_SAMPLES, Math.floor(visibleSamples.value * ZOOM_FACTOR))
+    const idx = findZoomIndex(visibleSamples.value)
+    // Step down one level, but only if we're actually at or above that level
+    const newIdx = ZOOM_LEVELS[idx] >= visibleSamples.value ? Math.max(0, idx - 1) : idx
+    const newVisible = ZOOM_LEVELS[newIdx]
     const mid = center ?? firstSample.value + Math.floor(visibleSamples.value / 2)
     const newFirst = mid - Math.floor(newVisible / 2)
     const { first: f, visible: v } = clamp(newFirst, newVisible)
@@ -55,7 +86,10 @@ export const useViewportStore = defineStore('viewport', () => {
 
   async function zoomOut(center = null) {
     if (!canZoomOut.value) return
-    const newVisible = Math.floor(visibleSamples.value / ZOOM_FACTOR)
+    const idx = findZoomIndex(visibleSamples.value)
+    // Step up one level
+    const newIdx = Math.min(ZOOM_LEVELS.length - 1, idx + 1)
+    const newVisible = ZOOM_LEVELS[newIdx]
     const mid = center ?? firstSample.value + Math.floor(visibleSamples.value / 2)
     const newFirst = mid - Math.floor(newVisible / 2)
     const { first: f, visible: v } = clamp(newFirst, newVisible)

--- a/Software/Web/src/stores/viewport.test.js
+++ b/Software/Web/src/stores/viewport.test.js
@@ -134,26 +134,40 @@ describe('useViewportStore', () => {
       expect(viewport.visibleSamples).toBe(10) // stays at MIN
     })
 
-    it('maintains center on zoom', async () => {
+    it('maintains center on zoom (default fraction=0.5)', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      // 23 is a zoom level (10, 15, 23, 34, ...)
       await viewport.setView(100, 23)
-      // Center is at 111, zoom in → 15
+      // Center is at 111, zoom in → 15, fraction=0.5
       await viewport.zoomIn()
       expect(viewport.visibleSamples).toBe(15)
-      // firstSample = 111 - floor(15/2) = 111 - 7 = 104
+      // firstSample = round(111 - 0.5 * 15) = round(103.5) = 104
       expect(viewport.firstSample).toBe(104)
     })
 
-    it('accepts custom center', async () => {
+    it('accepts anchor with fraction', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      await viewport.setView(0, 23)
-      await viewport.zoomIn(5)
-      // New visible = 15, centered on 5 → first = 5 - 7 = clamped to 0
-      expect(viewport.firstSample).toBe(0)
-      expect(viewport.visibleSamples).toBe(15)
+      await viewport.setView(100, 80)
+      // Cursor at sample 120 (fraction = (120-100)/80 = 0.25 from left)
+      await viewport.zoomIn(120, 0.25)
+      // New visible = 53, newFirst = round(120 - 0.25 * 53) = round(106.75) = 107
+      expect(viewport.firstSample).toBe(107)
+      expect(viewport.visibleSamples).toBe(53)
+    })
+
+    it('preserves screen position of anchor sample', async () => {
+      await setupCapture(1000)
+      const viewport = useViewportStore()
+      await viewport.setView(200, 120)
+      // Cursor at pixel 75% from left → sample = 200 + 0.75 * 120 = 290
+      const anchor = 290
+      const fraction = 0.75
+      await viewport.zoomIn(anchor, fraction)
+      // Verify anchor is still near 75% in the new viewport
+      const newFraction =
+        (anchor - viewport.firstSample) / viewport.visibleSamples
+      expect(newFraction).toBeCloseTo(0.75, 1)
     })
 
     it('snaps down from a non-level value', async () => {
@@ -175,6 +189,19 @@ describe('useViewportStore', () => {
       await viewport.setView(0, 15)
       await viewport.zoomOut()
       expect(viewport.visibleSamples).toBe(23) // next level up
+    })
+
+    it('preserves screen position of anchor on zoom out', async () => {
+      await setupCapture(1000)
+      const viewport = useViewportStore()
+      await viewport.setView(200, 80)
+      // Cursor at 30% from left → sample 224
+      const anchor = 224
+      const fraction = 0.3
+      await viewport.zoomOut(anchor, fraction)
+      const newFraction =
+        (anchor - viewport.firstSample) / viewport.visibleSamples
+      expect(newFraction).toBeCloseTo(0.3, 1)
     })
 
     it('does not zoom beyond total samples', async () => {

--- a/Software/Web/src/stores/viewport.test.js
+++ b/Software/Web/src/stores/viewport.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useViewportStore } from './viewport.js'
+import { useViewportStore, ZOOM_LEVELS } from './viewport.js'
 import { useCaptureStore } from './capture.js'
 
 // Need the same mocks as capture.test.js for device store transitive dependency
@@ -42,6 +42,28 @@ async function setupCapture(sampleCount) {
   await capture.loadCsv(`CH0\n${samples}`)
   return capture
 }
+
+describe('ZOOM_LEVELS', () => {
+  it('starts at minimum visible samples', () => {
+    expect(ZOOM_LEVELS[0]).toBe(10)
+  })
+
+  it('is strictly increasing', () => {
+    for (let i = 1; i < ZOOM_LEVELS.length; i++) {
+      expect(ZOOM_LEVELS[i]).toBeGreaterThan(ZOOM_LEVELS[i - 1])
+    }
+  })
+
+  it('contains only integers', () => {
+    for (const level of ZOOM_LEVELS) {
+      expect(Number.isInteger(level)).toBe(true)
+    }
+  })
+
+  it('covers a large range', () => {
+    expect(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]).toBeGreaterThanOrEqual(1e10)
+  })
+})
 
 describe('useViewportStore', () => {
   beforeEach(() => {
@@ -95,12 +117,13 @@ describe('useViewportStore', () => {
   })
 
   describe('zoomIn', () => {
-    it('halves visible range', async () => {
+    it('steps to next smaller zoom level', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      await viewport.setView(0, 200)
+      // Set to an exact zoom level (ZOOM_LEVELS includes 15)
+      await viewport.setView(0, 15)
       await viewport.zoomIn()
-      expect(viewport.visibleSamples).toBe(100)
+      expect(viewport.visibleSamples).toBe(10) // one step down
     })
 
     it('does not zoom below minimum', async () => {
@@ -114,32 +137,44 @@ describe('useViewportStore', () => {
     it('maintains center on zoom', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      await viewport.setView(100, 200)
-      // Center is at 200
+      // 23 is a zoom level (10, 15, 23, 34, ...)
+      await viewport.setView(100, 23)
+      // Center is at 111, zoom in → 15
       await viewport.zoomIn()
-      // New visible = 100, center should still be near 200
-      expect(viewport.firstSample).toBe(150)
-      expect(viewport.visibleSamples).toBe(100)
+      expect(viewport.visibleSamples).toBe(15)
+      // firstSample = 111 - floor(15/2) = 111 - 7 = 104
+      expect(viewport.firstSample).toBe(104)
     })
 
     it('accepts custom center', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      await viewport.setView(0, 200)
-      await viewport.zoomIn(50)
-      // New visible = 100, centered on 50
+      await viewport.setView(0, 23)
+      await viewport.zoomIn(5)
+      // New visible = 15, centered on 5 → first = 5 - 7 = clamped to 0
       expect(viewport.firstSample).toBe(0)
-      expect(viewport.visibleSamples).toBe(100)
+      expect(viewport.visibleSamples).toBe(15)
+    })
+
+    it('snaps down from a non-level value', async () => {
+      await setupCapture(1000)
+      const viewport = useViewportStore()
+      // 200 is between zoom levels 180 and 270
+      await viewport.setView(0, 200)
+      await viewport.zoomIn()
+      // findZoomIndex(200) finds 180 (largest <= 200), which is < 200, so stays at 180
+      expect(viewport.visibleSamples).toBe(180)
     })
   })
 
   describe('zoomOut', () => {
-    it('doubles visible range', async () => {
+    it('steps to next larger zoom level', async () => {
       await setupCapture(1000)
       const viewport = useViewportStore()
-      await viewport.setView(0, 100)
+      // 15 is a zoom level
+      await viewport.setView(0, 15)
       await viewport.zoomOut()
-      expect(viewport.visibleSamples).toBe(200)
+      expect(viewport.visibleSamples).toBe(23) // next level up
     })
 
     it('does not zoom beyond total samples', async () => {


### PR DESCRIPTION
- Store samples in a ring buffer to avoid GC pressure - this preallocates memory ahead of time
- Store multiple levels of decimated samples for performant waveform display at various zoom levels
- Display cursor under mouse and focus zoom in/out on it
- Control zoom with Shift+Scroll and +/- keys
- New timeline preview and scrolling
- Scrolling timeline with left/right arrows and optional ctrl / shift modifiers